### PR TITLE
Fix Railroad Boulder Cutscene

### DIFF
--- a/StardewArchipelago/GameModifications/EntranceRandomizer/ModEntranceManager.cs
+++ b/StardewArchipelago/GameModifications/EntranceRandomizer/ModEntranceManager.cs
@@ -37,7 +37,7 @@ namespace StardewArchipelago.GameModifications.EntranceRandomizer
             { "Badlands Entrance", "Custom_DesertRailway" },
             { "Enchanted Grove", "Custom_EnchantedGrove" },
             { "Grove Aurora Vineyard Warp", "Custom_EnchantedGrove|20|41" },
-            { "Grove Junimo Woods Warp", "Custom_EnchantedGrove|40|41" },
+            { "Grove Junimo Woods Warp", "Custom_EnchantedGrove|40|40" },
             { "Grove Outpost Warp", "Custom_EnchantedGrove|40|10" },
             { "Grove Farm Warp", "Custom_EnchantedGrove|30|14" },
             { "Grove Wizard Warp", "Custom_EnchantedGrove|17|25" },

--- a/StardewArchipelago/Locations/CodeInjections/Initializers/ModCodeInjectionInitializer.cs
+++ b/StardewArchipelago/Locations/CodeInjections/Initializers/ModCodeInjectionInitializer.cs
@@ -18,14 +18,6 @@ namespace StardewArchipelago.Locations.CodeInjections.Initializers
         {
             _archipelago = archipelago;
             InitializeModdedContent(monitor, modHelper, archipelago, locationChecker, shopReplacer, shopStockGenerator);
-            // Fix to remove dupes in Railroad Boulder
-            var railroadBoulderOrder = SpecialOrder.GetSpecialOrder("Clint2", null);
-            var railroadDupeCount = Game1.player.team.specialOrders.Count(x => x.questKey.Value.Equals("Clint2Again"));
-            while (railroadDupeCount > 1)
-            {
-                Game1.player.team.specialOrders.Remove(railroadBoulderOrder);
-                railroadDupeCount -= 1;
-            }
         }
 
         private static void InitializeModdedContent(IMonitor monitor, IModHelper modHelper, ArchipelagoClient archipelago, LocationChecker locationChecker, ShopReplacer shopReplacer, ShopStockGenerator shopStockGenerator)

--- a/StardewArchipelago/Locations/CodeInjections/Initializers/ModCodeInjectionInitializer.cs
+++ b/StardewArchipelago/Locations/CodeInjections/Initializers/ModCodeInjectionInitializer.cs
@@ -1,10 +1,12 @@
-﻿using StardewArchipelago.Archipelago;
+﻿using System.Linq;
+using StardewArchipelago.Archipelago;
 using StardewModdingAPI;
 using StardewArchipelago.Constants;
 using StardewArchipelago.GameModifications;
 using StardewArchipelago.GameModifications.CodeInjections.Modded;
 using StardewArchipelago.Locations.CodeInjections.Modded;
 using StardewArchipelago.Locations.CodeInjections.Modded.SVE;
+using StardewValley;
 
 namespace StardewArchipelago.Locations.CodeInjections.Initializers
 {
@@ -16,6 +18,14 @@ namespace StardewArchipelago.Locations.CodeInjections.Initializers
         {
             _archipelago = archipelago;
             InitializeModdedContent(monitor, modHelper, archipelago, locationChecker, shopReplacer, shopStockGenerator);
+            // Fix to remove dupes in Railroad Boulder
+            var railroadBoulderOrder = SpecialOrder.GetSpecialOrder("Clint2", null);
+            var railroadDupeCount = Game1.player.team.specialOrders.Count(x => x.questKey.Value.Equals("Clint2Again"));
+            while (railroadDupeCount > 1)
+            {
+                Game1.player.team.specialOrders.Remove(railroadBoulderOrder);
+                railroadDupeCount -= 1;
+            }
         }
 
         private static void InitializeModdedContent(IMonitor monitor, IModHelper modHelper, ArchipelagoClient archipelago, LocationChecker locationChecker, ShopReplacer shopReplacer, ShopStockGenerator shopStockGenerator)

--- a/StardewArchipelago/Locations/CodeInjections/Modded/CallableModData.cs
+++ b/StardewArchipelago/Locations/CodeInjections/Modded/CallableModData.cs
@@ -54,10 +54,16 @@ namespace StardewArchipelago.Locations.CodeInjections.Modded
             { "spring", "0 Custom_Martin_WarpRoom 1 3 3" }
         };
 
+        private static readonly Dictionary<string, string> _marlonNeedsSpringIGuess = new()
+        {
+            { "spring", "610 AdventureGuild 4 11 2"}
+        };
+
         private static readonly Dictionary<string, Dictionary<string, string>> characterToSchedule = new()
         {
             { "Claire", _claireScheduleWhenMovies },
-            { "Martin", _martinScheduleWhenMovies }
+            { "Martin", _martinScheduleWhenMovies },
+            { "MarlonFay", _marlonNeedsSpringIGuess }
         };
 
 
@@ -69,7 +75,7 @@ namespace StardewArchipelago.Locations.CodeInjections.Modded
             ReplaceCutscenes(Total_Static_Events);
             ReplaceCutscenes(Total_OnWarped_Events);
             GuntherInitializer();
-            ChangeScheduleForMovie();
+            ChangeSchedules();
         }
 
         private static void GenerateEventKeys()
@@ -134,7 +140,7 @@ namespace StardewArchipelago.Locations.CodeInjections.Modded
             }
         }
 
-        public void ChangeScheduleForMovie()
+        public void ChangeSchedules()
         {
             if (!_archipelago.SlotData.Mods.HasMod(ModNames.SVE) || _archipelago.GetReceivedItemCount(TheaterInjections.MOVIE_THEATER_ITEM) < 2)
             {

--- a/StardewArchipelago/Locations/CodeInjections/Modded/SVE/SVECutsceneInjections.cs
+++ b/StardewArchipelago/Locations/CodeInjections/Modded/SVE/SVECutsceneInjections.cs
@@ -96,27 +96,25 @@ namespace StardewArchipelago.Locations.CodeInjections.Modded.SVE
             }
         }
 
-        public static void ResetLocalState_PlayRailroadBoulderCutsceneIfConditionsAreMet_Postfix(GameLocation __instance)
+        public static bool EndBehaviors_AddRailroadBoulderIfIridiumBomb_Prefix(string[] split, Event __instance)
         {
             try
             {
-                var bombBeforeQuest = Game1.player.eventsSeen.Contains(RAILROAD_BOULDER_ID) && Game1.player.eventsSeen.Contains(IRIDIUM_BOMB_ID);
-                if (!Game1.player.hasSkullKey || !bombBeforeQuest)
+                if (__instance.id != RAILROAD_BOULDER_ID || !Game1.player.mailReceived.Contains("RailroadBoulderRemoved"))
                 {
-                    return;
+                    return true;
                 }
-
-                // Add a fake Special Order for Clint's boulder destruction because the real one gets removed by SVE when the actual boulder is removed
+                //Change the key so it doesn't get deleted
                 var railroadBoulderOrder = SpecialOrder.GetSpecialOrder("Clint2", null);
                 railroadBoulderOrder.questKey.Value = RAILROAD_KEY;
                 Game1.player.team.specialOrders.Add(railroadBoulderOrder);
 
-                return;
+                return true;
             }
             catch (Exception ex)
             {
-                _monitor.Log($"Failed in {nameof(ResetLocalState_PlayRailroadBoulderCutsceneIfConditionsAreMet_Postfix)}:\n{ex}", LogLevel.Error);
-                return;
+                _monitor.Log($"Failed in {nameof(EndBehaviors_AddRailroadBoulderIfIridiumBomb_Prefix)}:\n{ex}", LogLevel.Error);
+                return true;
             }
         }
 

--- a/StardewArchipelago/Locations/CodeInjections/Modded/SVE/SVECutsceneInjections.cs
+++ b/StardewArchipelago/Locations/CodeInjections/Modded/SVE/SVECutsceneInjections.cs
@@ -58,6 +58,7 @@ namespace StardewArchipelago.Locations.CodeInjections.Modded.SVE
             { "Farm|GuntherRustyKey", new[] {"103042015/e 295672/t 600 700/H"}}
         };
 
+        // public override bool checkForAction(Farmer who, bool justCheckingForActivity = false)
         public static bool CheckForAction_LanceChest_Prefix(Chest __instance, Farmer who, bool justCheckingForActivity, ref bool __result)
         {
             try
@@ -96,25 +97,26 @@ namespace StardewArchipelago.Locations.CodeInjections.Modded.SVE
             }
         }
 
+        // public void endBehaviors(string[] split, GameLocation location)
         public static bool EndBehaviors_AddRailroadBoulderIfIridiumBomb_Prefix(string[] split, Event __instance)
         {
             try
             {
                 if (__instance.id != RAILROAD_BOULDER_ID || !Game1.player.mailReceived.Contains("RailroadBoulderRemoved"))
                 {
-                    return true;
+                    return true; // run original logic
                 }
                 //Change the key so it doesn't get deleted
                 var railroadBoulderOrder = SpecialOrder.GetSpecialOrder("Clint2", null);
                 railroadBoulderOrder.questKey.Value = RAILROAD_KEY;
                 Game1.player.team.specialOrders.Add(railroadBoulderOrder);
 
-                return true;
+                return true; // run original logic
             }
             catch (Exception ex)
             {
                 _monitor.Log($"Failed in {nameof(EndBehaviors_AddRailroadBoulderIfIridiumBomb_Prefix)}:\n{ex}", LogLevel.Error);
-                return true;
+                return true; // run original logic
             }
         }
 

--- a/StardewArchipelago/Locations/Patcher/ModLocationPatcher.cs
+++ b/StardewArchipelago/Locations/Patcher/ModLocationPatcher.cs
@@ -307,7 +307,7 @@ namespace StardewArchipelago.Locations.Patcher
             );
 
             _harmony.Patch(
-                original: AccessTools.Method(typeof(Event), nameof(Event.skipEvent)),
+                original: AccessTools.Method(typeof(Event), nameof(Event.endBehaviors)),
                 prefix: new HarmonyMethod(typeof(SVECutsceneInjections), nameof(SVECutsceneInjections.EndBehaviors_AddRailroadBoulderIfIridiumBomb_Prefix))
             );
         }

--- a/StardewArchipelago/Locations/Patcher/ModLocationPatcher.cs
+++ b/StardewArchipelago/Locations/Patcher/ModLocationPatcher.cs
@@ -308,7 +308,7 @@ namespace StardewArchipelago.Locations.Patcher
 
             _harmony.Patch(
                 original: AccessTools.Method(typeof(Event), nameof(Event.skipEvent)),
-                postfix: new HarmonyMethod(typeof(SVECutsceneInjections), nameof(SVECutsceneInjections.ResetLocalState_PlayRailroadBoulderCutsceneIfConditionsAreMet_Postfix))
+                prefix: new HarmonyMethod(typeof(SVECutsceneInjections), nameof(SVECutsceneInjections.EndBehaviors_AddRailroadBoulderIfIridiumBomb_Prefix))
             );
         }
     }

--- a/StardewArchipelago/ModEntry.cs
+++ b/StardewArchipelago/ModEntry.cs
@@ -28,6 +28,7 @@ using StardewValley.Locations;
 using StardewArchipelago.GameModifications.Modded;
 using StardewArchipelago.Locations.CodeInjections.Vanilla.MonsterSlayer;
 using StardewArchipelago.Locations.CodeInjections.Modded;
+using StardewArchipelago.Constants;
 
 namespace StardewArchipelago
 {
@@ -285,6 +286,7 @@ namespace StardewArchipelago
                 TravelingMerchantInjections.UpdateTravelingMerchantForToday(Game1.getLocationFromName("Forest") as Forest, Game1.dayOfMonth);
                 SeasonsRandomizer.ChangeMailKeysBasedOnSeasonsToDaysElapsed();
                 _callableModData = new CallableModData(Monitor, _archipelago);
+                DoBugsCleanup();
                 Game1.chatBox?.addMessage($"Connected to Archipelago as {_archipelago.SlotData.SlotName}. Type !!help for client commands", Color.Green);
 
             }
@@ -368,6 +370,18 @@ namespace StardewArchipelago
 
         private void DoBugsCleanup()
         {
+            // Fix to remove dupes in Railroad Boulder
+            if (!_archipelago.SlotData.Mods.HasMod(ModNames.SVE))
+            {
+                return;
+            }
+            var railroadBoulderOrder = SpecialOrder.GetSpecialOrder("Clint2", null);
+            var railroadDupeCount = Game1.player.team.specialOrders.Count(x => x.questKey.Value.Equals("Clint2Again"));
+            while (railroadDupeCount > 1)
+            {
+                Game1.player.team.specialOrders.Remove(railroadBoulderOrder);
+                railroadDupeCount -= 1;
+            }
         }
 
         private void OnDayEnding(object sender, DayEndingEventArgs e)

--- a/StardewArchipelago/ModEntry.cs
+++ b/StardewArchipelago/ModEntry.cs
@@ -286,7 +286,6 @@ namespace StardewArchipelago
                 TravelingMerchantInjections.UpdateTravelingMerchantForToday(Game1.getLocationFromName("Forest") as Forest, Game1.dayOfMonth);
                 SeasonsRandomizer.ChangeMailKeysBasedOnSeasonsToDaysElapsed();
                 _callableModData = new CallableModData(Monitor, _archipelago);
-                DoBugsCleanup();
                 Game1.chatBox?.addMessage($"Connected to Archipelago as {_archipelago.SlotData.SlotName}. Type !!help for client commands", Color.Green);
 
             }


### PR DESCRIPTION
The railroad cutscene would constantly add itself.

- Adds temporary code to reduce the quests to just one quest on load.
- Fixes the inconsistency when getting it; now if you watch the cutscene it gives you one quest, only in that event, regardless of state.