### PR TITLE
Sve special orders

### DIFF
--- a/StardewArchipelago/Locations/CodeInjections/Vanilla/SpecialOrderInjections.cs
+++ b/StardewArchipelago/Locations/CodeInjections/Vanilla/SpecialOrderInjections.cs
@@ -67,6 +67,7 @@ namespace StardewArchipelago.Locations.CodeInjections.Vanilla
                 if (_locationChecker.IsLocationMissingAndExists(specialOrderName) & !_vanillaSpecialOrderReward.Contains(specialOrderName))
                 {
                     __result.rewards.Clear();
+                    Game1.player.team.specialOrders.Remove(__result); // Might as well, and it cleans up SVE special orders.
                 }
             }
             catch (Exception ex)

--- a/StardewArchipelago/Locations/Patcher/ModLocationPatcher.cs
+++ b/StardewArchipelago/Locations/Patcher/ModLocationPatcher.cs
@@ -308,7 +308,13 @@ namespace StardewArchipelago.Locations.Patcher
 
             _harmony.Patch(
                 original: AccessTools.Method(typeof(Event), nameof(Event.endBehaviors)),
-                prefix: new HarmonyMethod(typeof(SVECutsceneInjections), nameof(SVECutsceneInjections.EndBehaviors_AddRailroadBoulderIfIridiumBomb_Prefix))
+                prefix: new HarmonyMethod(typeof(SVECutsceneInjections), nameof(SVECutsceneInjections.EndBehaviors_AddSpecialOrderAfterEvent_Prefix))
+            );
+            var specialOrderAfterEventsType = AccessTools.TypeByName("AddSpecialOrdersAfterEvents");
+
+            _harmony.Patch(
+                original: AccessTools.Method(specialOrderAfterEventsType, "UpdateSpecialOrders"),
+                prefix: new HarmonyMethod(typeof(SVECutsceneInjections), nameof(SVECutsceneInjections.UpdateSpecialOrders_StopDeletingSpecialOrders_Prefix))
             );
         }
     }

--- a/StardewArchipelago/ModEntry.cs
+++ b/StardewArchipelago/ModEntry.cs
@@ -376,6 +376,11 @@ namespace StardewArchipelago
             }
             var railroadBoulderOrder = SpecialOrder.GetSpecialOrder("Clint2", null);
             var railroadDupeCount = Game1.player.team.specialOrders.Count(x => x.questKey.Value.Equals("Clint2Again"));
+            if (railroadDupeCount <= 1)
+            {
+                return;
+            }
+            railroadBoulderOrder.questKey.Value = "Clint2Again";
             while (railroadDupeCount > 1)
             {
                 Game1.player.team.specialOrders.Remove(railroadBoulderOrder);


### PR DESCRIPTION
It seems every SVE quest is handled so strictly to events that the best way to resolve the whole issue is to simply re-tie removal to the reward of the special order, and addition to the event only (no removal on seeing another event).

So it'll handle railroad boulder and everything else, or should.  Also I was told that my patch didn't remove all of the dupes, so this should hopefully do it.