### PR TITLE
Content Patcher Support

### DIFF
--- a/Documentation/Supported Mods.md
+++ b/Documentation/Supported Mods.md
@@ -43,6 +43,8 @@ Custom NPCs:
 - [Custom NPC - Riley](https://www.nexusmods.com/stardewvalley/mods/5811), by SG, Version 1.2.2
 - [Alecto the Witch](https://www.nexusmods.com/stardewvalley/mods/10671), by zoedoll, Version 1.1.7
 
+In addition, a [Content Patcher mod](https://github.com/Witchybun/SDV-Randomizer-Content-Patcher/releases) may be required for the mod to properly function alongside your game.  Include these alongside StardewArchipelago.
+
 ## How to add supported mods to my Archipelago slot?
 
 To include supported mods in your multiworld slot, you need to include a section in your yaml settings called "mods".

--- a/StardewArchipelago/Archipelago/ArchipelagoClient.cs
+++ b/StardewArchipelago/Archipelago/ArchipelagoClient.cs
@@ -77,6 +77,12 @@ namespace StardewArchipelago.Archipelago
                 DisconnectPermanently();
                 return;
             }
+
+            if (!SlotData.Mods.IsPatcherStateCorrect(_modHelper, out errorMessage))
+            {
+                DisconnectPermanently();
+                return;
+            }
 #endif
         }
 

--- a/StardewArchipelago/Archipelago/ModsManager.cs
+++ b/StardewArchipelago/Archipelago/ModsManager.cs
@@ -77,6 +77,33 @@ namespace StardewArchipelago.Archipelago
             return valid;
         }
 
+        public bool IsPatcherStateCorrect(IModHelper modHelper, out string errorMessage)
+        {
+            var loadedModData = modHelper.ModRegistry.GetAll().ToList();
+            errorMessage = $"The slot you are connecting to requires a content patcher,\r\n mod, but not all expected mods are installed and active.";
+            var valid = true;
+            foreach (var modName in _activeMods)
+            {
+                if (!ModVersions.CPVersions.ContainsKey(modName))
+                {
+                    continue;
+                }
+                var contentName = ModVersions.CPVersions[modName].Keys.First();
+                var contentVersion = ModVersions.CPVersions[modName].Values.First();
+                if (IsModActiveAndCorrectVersion(loadedModData, contentName, contentVersion, out var existingVersion))
+                {
+                    continue;
+                }
+
+                valid = false;
+                errorMessage += $"{Environment.NewLine}\tMod: {contentName}, expected version: {contentVersion}, current Version: {existingVersion}";
+
+            }
+
+            return valid;
+
+        }
+
         private static bool IsModActiveAndCorrectVersion(List<IModInfo> loadedModData, string desiredModName, string desiredVersion, out string existingVersion)
         {
             var normalizedDesiredModName = GetNormalizedModName(desiredModName);

--- a/StardewArchipelago/Archipelago/ModsManager.cs
+++ b/StardewArchipelago/Archipelago/ModsManager.cs
@@ -88,15 +88,14 @@ namespace StardewArchipelago.Archipelago
                 {
                     continue;
                 }
-                var contentName = ModVersions.CPVersions[modName].Keys.First();
-                var contentVersion = ModVersions.CPVersions[modName].Values.First();
-                if (IsModActiveAndCorrectVersion(loadedModData, contentName, contentVersion, out var existingVersion))
+                var requirement = ModVersions.CPVersions[modName];
+                if (IsModActiveAndCorrectVersion(loadedModData, requirement.ContentPatcherMod, requirement.ContentPatcherVersion, out var existingVersion))
                 {
                     continue;
                 }
 
                 valid = false;
-                errorMessage += $"{Environment.NewLine}\tMod: {contentName}, expected version: {contentVersion}, current Version: {existingVersion}";
+                errorMessage += $"{Environment.NewLine}\tMod: {requirement.ContentPatcherMod}, expected version: {requirement.ContentPatcherVersion}, current Version: {existingVersion}";
 
             }
 

--- a/StardewArchipelago/Constants/ModNames.cs
+++ b/StardewArchipelago/Constants/ModNames.cs
@@ -26,5 +26,9 @@
         public const string SVE = "Stardew Valley Expanded";
         public const string ALECTO = "Alecto the Witch";
         public const string DISTANT_LANDS = "Distant Lands - Witch Swamp Overhaul";
+
+        public const string AP_SVE = "StardewArchipelago - Stardew Valley Expanded";
+        public const string AP_ALECTO = "StardewArchipelago - Alecto the Witch";
+        public const string AP_JASPER = "StardewArchipelago - Professor Jasper Thomas";
     }
 }

--- a/StardewArchipelago/Constants/ModVersions.cs
+++ b/StardewArchipelago/Constants/ModVersions.cs
@@ -32,10 +32,21 @@ namespace StardewArchipelago.Constants
             { ModNames.DISTANT_LANDS, "1.0.7"}
         };
 
-        public static readonly Dictionary<string, Dictionary<string, string>> CPVersions = new(){
-            { ModNames.SVE, new(){{ ModNames.AP_SVE, "1.0.0" }} },
-            { ModNames.ALECTO, new(){{ ModNames.AP_ALECTO, "1.0.0" }} },
-            { ModNames.JASPER, new(){{ ModNames.AP_JASPER, "1.0.0"}} }
+        public class ContentPatcherRequirement{
+            public string ContentPatcherMod {get; private set;}
+            public string ContentPatcherVersion {get; private set;}
+
+            public ContentPatcherRequirement(string patchName, string patchVersion)
+            {
+                ContentPatcherMod = patchName;
+                ContentPatcherVersion = patchVersion;
+            }
+        }
+
+        public static readonly Dictionary<string, ContentPatcherRequirement> CPVersions = new(){
+            {ModNames.SVE, new ContentPatcherRequirement(ModNames.AP_SVE, "1.0.0")},
+            {ModNames.ALECTO, new ContentPatcherRequirement(ModNames.AP_ALECTO, "1.0.0")},
+            {ModNames.JASPER, new ContentPatcherRequirement(ModNames.AP_JASPER, "1.0.0")}
         };
 }
 }

--- a/StardewArchipelago/Constants/ModVersions.cs
+++ b/StardewArchipelago/Constants/ModVersions.cs
@@ -31,5 +31,11 @@ namespace StardewArchipelago.Constants
             { ModNames.ALECTO, "1.1.7"},
             { ModNames.DISTANT_LANDS, "1.0.7"}
         };
+
+        public static readonly Dictionary<string, Dictionary<string, string>> CPVersions = new(){
+            { ModNames.SVE, new(){{ ModNames.AP_SVE, "1.0.0" }} },
+            { ModNames.ALECTO, new(){{ ModNames.AP_ALECTO, "1.0.0" }} },
+            { ModNames.JASPER, new(){{ ModNames.AP_JASPER, "1.0.0"}} }
+        };
 }
 }

--- a/StardewArchipelago/GameModifications/CodeInjections/TheaterInjections.cs
+++ b/StardewArchipelago/GameModifications/CodeInjections/TheaterInjections.cs
@@ -194,6 +194,10 @@ namespace StardewArchipelago.GameModifications.CodeInjections
                     {
                         __instance.crackOpenAbandonedJojaMartDoor();
                     }
+                    if (!Game1.player.mailReceived.Contains(string.Join("ap",ABANDONED_JOJA_MART)))
+                    {
+                        Game1.player.mailReceived.Add("apAbandonedJojaMart");
+                    }
                 }
                 else
                 {

--- a/StardewArchipelago/Items/Unlocks/SVEUnlockManager.cs
+++ b/StardewArchipelago/Items/Unlocks/SVEUnlockManager.cs
@@ -167,16 +167,16 @@ namespace StardewArchipelago.Items.Unlocks
             return new LetterEventSeenAttachment(receivedItem, events);
         }
 
-        private LetterEventSeenAttachment SendJunimoNote(ReceivedItem receivedItem)
+        private LetterVanillaAttachment SendJunimoNote(ReceivedItem receivedItem)
         {
-            var events = AURORA_EVENT;
-            return new LetterEventSeenAttachment(receivedItem, events);
+            var vineyard = "apAuroraVineyard";
+            return new LetterVanillaAttachment(receivedItem, vineyard, true);
         }
 
-        private LetterEventSeenAttachment SendAcceptanceLetter(ReceivedItem receivedItem)
+        private LetterVanillaAttachment SendAcceptanceLetter(ReceivedItem receivedItem)
         {
-            var events = MORGAN_EVENT;
-            return new LetterEventSeenAttachment(receivedItem, events);
+            var school = "apMorganSchooling";
+            return new LetterVanillaAttachment(receivedItem, school, true);
         }
     }
 }

--- a/StardewArchipelago/Locations/CodeInjections/Modded/CallableModData.cs
+++ b/StardewArchipelago/Locations/CodeInjections/Modded/CallableModData.cs
@@ -1,161 +1,21 @@
-using System;
-using System.Linq;
 using System.Collections.Generic;
-using Microsoft.Xna.Framework;
 using StardewModdingAPI;
 using StardewArchipelago.Archipelago;
 using StardewArchipelago.Constants;
 using StardewValley;
-using StardewArchipelago.Locations.CodeInjections.Modded.SVE;
-using StardewArchipelago.GameModifications.CodeInjections;
 
 namespace StardewArchipelago.Locations.CodeInjections.Modded
 {
     public class CallableModData
     {
-        private static readonly Dictionary<string, string[]> Base_Static_Events = new()
-        {
-
-        };
-
-        private static readonly Dictionary<string, string[]> Total_Static_Events = new()
-        {
-
-        };
-
-        private static readonly Dictionary<string, string[]> Base_OnWarped_Events = new()
-        {
-
-        };
-
-        public static Dictionary<string, string[]> Total_OnWarped_Events = new()
-        {
-
-        };
-
         private static IMonitor _monitor;
         private static ArchipelagoClient _archipelago;
-
-        private static readonly Dictionary<string, string> _claireScheduleWhenMovies = new()
-        {
-            { "Mon", "0 Custom_Claire_WarpRoom 1 3 3/650 Town 92 44 2/850 MovieTheater 7 5 2 Claire_Blink/2130 BusStop 12 8 0/2340 Custom_DayEnd_WarpRoom 3 3 0" },
-            { "Wed", "0 Custom_Claire_WarpRoom 1 3 3/650 Town 92 44 2/850 MovieTheater 7 5 2 Claire_Blink/2130 BusStop 12 8 0/2340 Custom_DayEnd_WarpRoom 3 3 0" },
-            { "Thu", "0 Custom_Claire_WarpRoom 1 3 3/650 Town 92 44 2/850 MovieTheater 7 5 2 Claire_Blink/2130 BusStop 12 8 0/2340 Custom_DayEnd_WarpRoom 3 3 0" },
-            { "Fri", "0 Custom_Claire_WarpRoom 1 3 3/650 Town 92 44 2/850 MovieTheater 7 5 2 Claire_Blink/2130 BusStop 12 8 0/2340 Custom_DayEnd_WarpRoom 3 3 0" },
-            { "Sun", "0 Custom_Claire_WarpRoom 1 3 3/650 Town 92 44 2/850 MovieTheater 7 5 2 Claire_Blink/2130 BusStop 12 8 0/2340 Custom_DayEnd_WarpRoom 3 3 0" },
-            { "Sat", "0 Custom_Claire_WarpRoom 1 3 3" },
-            { "spring", "0 Custom_Claire_WarpRoom 1 3 3" }
-        };
-
-        private static readonly Dictionary<string, string> _martinScheduleWhenMovies = new()
-        {
-            { "Tue", "0 Custom_Martin_WarpRoom 1 3 3/650 Town 92 44 2/850 MovieTheater 7 5 2 Martin_Blink/1530 BusStop 12 8 0/1740 Custom_DayEnd_WarpRoom 3 3 0" },
-            { "Sat", "0 Custom_Martin_WarpRoom 1 3 3/650 Town 92 44 2/850 MovieTheater 7 5 2 Martin_Blink/2130 BusStop 12 8 0/2340 Custom_DayEnd_WarpRoom 3 3 0" },
-            { "spring", "0 Custom_Martin_WarpRoom 1 3 3" }
-        };
-
-        private static readonly Dictionary<string, string> _marlonNeedsSpringIGuess = new()
-        {
-            { "spring", "610 AdventureGuild 4 11 2"}
-        };
-
-        private static readonly Dictionary<string, Dictionary<string, string>> characterToSchedule = new()
-        {
-            { "Claire", _claireScheduleWhenMovies },
-            { "Martin", _martinScheduleWhenMovies },
-            { "MarlonFay", _marlonNeedsSpringIGuess }
-        };
-
 
         public CallableModData(IMonitor monitor, ArchipelagoClient archipelago)
         {
             _monitor = monitor;
             _archipelago = archipelago;
-            GenerateEventKeys();
-            ReplaceCutscenes(Total_Static_Events);
-            ReplaceCutscenes(Total_OnWarped_Events);
             GuntherInitializer();
-            ChangeSchedules();
-        }
-
-        private static void GenerateEventKeys()
-        {
-            foreach (var (eventMapName, eventKeys) in Base_OnWarped_Events)
-            {
-                Total_OnWarped_Events[eventMapName] = eventKeys;
-            }
-
-            foreach (var (eventMapName, eventKeys) in Base_Static_Events)
-            {
-                Total_Static_Events[eventMapName] = eventKeys;
-            }
-
-            if (_archipelago.SlotData.Mods.HasMod(ModNames.SVE))
-            {
-                foreach (var (eventMapName, eventKeys) in SVECutsceneInjections.SVE_OnWarped_Events)
-                {
-                    Total_OnWarped_Events[eventMapName] = eventKeys;
-                }
-
-                foreach (var (eventMapName, eventKeys) in SVECutsceneInjections.SVE_Static_Events)
-                {
-                    Total_Static_Events[eventMapName] = eventKeys;
-                }
-            }
-
-        }
-
-        public void ReplaceAllOnWarpedEvents()
-        {
-            ReplaceCutscenes(Total_OnWarped_Events);
-        }
-
-        // These events only require to load at initialization due to lack of "When" requirements from CP.
-        private void ReplaceCutscenes(Dictionary<string, string[]> events)
-        {
-            foreach (var (eventMapName, eventKeys) in events)
-            {
-                var mapKey = eventMapName.Split("|");
-                var mapName = mapKey[0];
-                var eventID = mapKey[1];
-                var currentMapEventData = Game1.content.Load<Dictionary<string, string>>("Data\\Events\\" + mapName);
-                foreach (var eventKey in eventKeys)
-                {
-
-                    var newEventKey = "";
-                    if (eventID == "")
-                        eventID = eventKey.Split("/")[0];
-                    // If CP does not add the event yet, continue.
-                    if (!currentMapEventData.ContainsKey(eventKey))
-                    {
-                        continue;
-                    }
-
-                    // Append self-reference as requirement, or AP oriented event key.
-                    newEventKey = eventKey + "/e " + eventID;
-                    var eventData = currentMapEventData[eventKey];
-                    currentMapEventData.Remove(eventKey);
-                    currentMapEventData[newEventKey] = eventData;
-                }
-            }
-        }
-
-        public void ChangeSchedules()
-        {
-            if (!_archipelago.SlotData.Mods.HasMod(ModNames.SVE) || _archipelago.GetReceivedItemCount(TheaterInjections.MOVIE_THEATER_ITEM) < 2)
-            {
-                return;
-            }
-
-            foreach (var name in characterToSchedule.Keys)
-            {
-                var loaded_schedules = Game1.content.Load<Dictionary<string, string>>($"Characters\\Schedules\\{name}");
-                var modified_schedules = characterToSchedule[name];
-                foreach (var day in modified_schedules)
-                {
-                    loaded_schedules[day.Key] = characterToSchedule[name][day.Key];
-                }
-            }
         }
 
         public void GuntherInitializer()

--- a/StardewArchipelago/Locations/CodeInjections/Vanilla/ShippingInjections.cs
+++ b/StardewArchipelago/Locations/CodeInjections/Vanilla/ShippingInjections.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using StardewArchipelago.Archipelago;
 using StardewArchipelago.Goals;
@@ -110,7 +111,8 @@ namespace StardewArchipelago.Locations.CodeInjections.Vanilla
 
             if (name.Contains("moonslime.excavation."))
             {
-                name = shippedItem.DisplayName.Replace("Woooden", "Wooden"); //Temporary fix; will break for chinese speaking players only atm
+                TextInfo ti = CultureInfo.CurrentCulture.TextInfo;
+                name = ti.ToTitleCase(shippedItem.DisplayName.Replace("Woooden", "Wooden"));
             }
 
             if (shippedItem is not Object shippedObject)

--- a/StardewArchipelago/Locations/CodeInjections/Vanilla/ShippingInjections.cs
+++ b/StardewArchipelago/Locations/CodeInjections/Vanilla/ShippingInjections.cs
@@ -110,7 +110,7 @@ namespace StardewArchipelago.Locations.CodeInjections.Vanilla
 
             if (name.Contains("moonslime.excavation."))
             {
-                name = shippedItem.DisplayName; //Temporary fix; will break for chinese speaking players only atm
+                name = shippedItem.DisplayName.Replace("Woooden", "Wooden"); //Temporary fix; will break for chinese speaking players only atm
             }
 
             if (shippedItem is not Object shippedObject)

--- a/StardewArchipelago/ModEntry.cs
+++ b/StardewArchipelago/ModEntry.cs
@@ -380,6 +380,21 @@ namespace StardewArchipelago
                 Game1.player.team.specialOrders.Remove(railroadBoulderOrder);
                 railroadDupeCount -= 1;
             }
+            // Async Fix for the change from eventsSeen to mailReceived checks.
+            var deprecatedEvents = new Dictionary<int, string>(){{658059254, "apAuroraVineyard"}, {658078924, "apMorganSchooling"}};
+            foreach (var (id, mail) in deprecatedEvents)
+            {
+                if (Game1.player.eventsSeen.Contains(id))
+                {
+                    Game1.player.eventsSeen.Remove(id);
+                    Game1.player.mailReceived.Add(mail);
+                }
+            }
+            // Async fix for the change in call to fix Morris/Claire/Martin
+            if (!Game1.player.mailReceived.Contains("apAbandonedJojaMart") && _archipelago.HasReceivedItem("Progressive Movie Theater"))
+            {
+                Game1.player.mailReceived.Add("apAbandonedJojaMart");
+            }
         }
 
         private void OnDayEnding(object sender, DayEndingEventArgs e)

--- a/StardewArchipelago/ModEntry.cs
+++ b/StardewArchipelago/ModEntry.cs
@@ -100,7 +100,6 @@ namespace StardewArchipelago
             _helper.Events.GameLoop.DayStarted += this.OnDayStarted;
             _helper.Events.GameLoop.DayEnding += this.OnDayEnding;
             _helper.Events.GameLoop.ReturnedToTitle += this.OnReturnedToTitle;
-            _helper.Events.Player.Warped += this.OnWarped;
 
 
             _helper.ConsoleCommands.Add("connect_override", $"Overrides your next connection to Archipelago. {CONNECT_SYNTAX}", this.OnCommandConnectToArchipelago);
@@ -301,11 +300,6 @@ namespace StardewArchipelago
             Monitor.Log("You are not allowed to load a save without connecting to Archipelago", LogLevel.Error);
             // TitleMenu.subMenu = previousMenu;
             Game1.ExitToTitle();
-        }
-
-        private void OnWarped(object sender, WarpedEventArgs e)
-        {
-            _callableModData.ReplaceAllOnWarpedEvents();
         }
 
         private void ReadPersistentArchipelagoData()


### PR DESCRIPTION
Removes a lot of the code dealing with modifying events and schedules.  Instead, these will be handled by content patchers for a more consistent experience.  These can be obtained from here:

https://github.com/Witchybun/SDV-Randomizer-Content-Patcher

The supported mods documentation now includes a link to this, the mods that are modified, and why.