### PR TITLE
New SVE Feature: Junimo Woods Bartering + Bear Bartering

### DIFF
--- a/StardewArchipelago/GameModifications/CodeInjections/Modded/JunimoShopInjections.cs
+++ b/StardewArchipelago/GameModifications/CodeInjections/Modded/JunimoShopInjections.cs
@@ -220,5 +220,28 @@ namespace StardewArchipelago.GameModifications.CodeInjections.Modded
                 return true; // run original logic
             }
         }
+
+        // public void resetFriendshipsForNewDay()
+        public static void ResetFriendshipsForNewDay_KissForeheads_Postfix(Farmer __instance)
+        {
+            try
+            {
+                if (Game1.player.mailReceived.Contains("purpleJunimoKiss"))
+                {
+                    foreach (var friendship in Game1.player.friendshipData.Keys)
+                    {
+                        var friend = Game1.getCharacterFromName(friendship);
+                        Game1.player.changeFriendship(100, friend);
+                    }
+                    Game1.player.mailReceived.Remove("purpleJunimoKiss");
+                }
+                return; // don't run original logic
+            }
+            catch (Exception ex)
+            {
+                _monitor.Log($"Failed in {nameof(ResetFriendshipsForNewDay_KissForeheads_Postfix)}:\n{ex}", LogLevel.Error);
+                return; // run original logic
+            }
+        }
     }
 }

--- a/StardewArchipelago/GameModifications/CodeInjections/Modded/JunimoShopInjections.cs
+++ b/StardewArchipelago/GameModifications/CodeInjections/Modded/JunimoShopInjections.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using Microsoft.Xna.Framework;
 using StardewArchipelago.Archipelago;
 using StardewArchipelago.GameModifications.Modded;
+using StardewArchipelago.Locations.CodeInjections.Vanilla.Relationship;
 using StardewArchipelago.Stardew;
 using StardewModdingAPI;
 using StardewValley;
@@ -19,6 +20,14 @@ namespace StardewArchipelago.GameModifications.CodeInjections.Modded
         private static ShopStockGenerator _shopStockGenerator;
         private static StardewItemManager _stardewItemManager;
         private static JunimoShopGenerator _junimoShopGenerator;
+        private static readonly string Question = "Me love purple thing-a-ma-bobs!  Could give VERY special gift!  You want?";
+        private static readonly string Money = "Weird yellow rocks for {0} {1}.";
+        private static readonly string Dewdrop = "Blue tasty under pretty tree for {0} {1}.";
+        private static readonly string Friendship = "Kiss many people on forehead for {0} {1}.";
+        private static readonly Response Nothing = new("No", "Nothing for now!");
+        private static Dictionary<string, PurpleJunimo> PurpleJunimoOptions {get; set;}
+        private static NPC DaJunimo = new();
+        private static readonly string _junimoDialogueKey = "PurpleJunimoVendor";
 
         
         private static readonly List<string> _junimoFirstItems = new(){
@@ -79,10 +88,12 @@ namespace StardewArchipelago.GameModifications.CodeInjections.Modded
                 var color = _firstItemToColor[firstItemForSale];
                 if (color == "Purple")
                 {
-                    // Will be worked on later
-                    /*var purpleJunimo = __instance.portraitPerson;
+                    var purpleJunimo = __instance.portraitPerson;
                     __instance.exitThisMenuNoSound();
-                    _junimoShopGenerator.PurpleJunimoSpecialShop(purpleJunimo);*/
+                    DaJunimo = purpleJunimo;
+                    DaJunimo.Name = "Purple Junimo";
+                    DaJunimo.displayName = "Purple Junimo";
+                    PurpleJunimoSpecialShop();
                     return true;
                 }
                 __instance.itemPriceAndStock = _junimoShopGenerator.GetJunimoShopStock(color, __instance.itemPriceAndStock);
@@ -93,6 +104,110 @@ namespace StardewArchipelago.GameModifications.CodeInjections.Modded
             catch (Exception ex)
             {
                 _monitor.Log($"Failed in {nameof(Update_JunimoWoodsAPShop_Prefix)}:\n{ex}", LogLevel.Error);
+                return true; // run original logic
+            }
+        }
+
+                private class PurpleJunimo
+        {
+            public StardewItem OfferedItem {get; set;}
+            public int Amount {get; set;}
+        }
+
+        public static void PurpleJunimoSpecialShop()
+        {
+            var junimoWoods = Game1.player.currentLocation;
+            var friendsMet = Game1.player.friendshipData.Count();
+            var fakeStock = new Dictionary<string, int>(){
+                {"Money", 10000},
+                {"Dewdrop", 500},
+                {"Friendship", 200 * friendsMet}
+            };
+            PurpleJunimoOptions = new Dictionary<string, PurpleJunimo>();
+            var randomSeed = 0;
+            foreach (var item in fakeStock)
+            {
+                var currentMonth = (int)(Game1.stats.daysPlayed / 28) + 1;
+                var random = new Random((int)Game1.uniqueIDForThisGame / 2 + currentMonth + randomSeed);
+                var itemToTrade = _junimoShopGenerator.PurpleItems.ElementAt(random.Next(_junimoShopGenerator.PurpleItems.Count));
+                var stardewItem = _stardewItemManager.GetObjectById(itemToTrade.Key);
+                var itemToTradeTotal = JunimoShopGenerator.ExchangeRate(item.Value, itemToTrade.Value);
+                PurpleJunimoOptions[item.Key] = new PurpleJunimo(){
+                    OfferedItem = stardewItem,
+                    Amount = Math.Max(itemToTradeTotal[1] / itemToTradeTotal[0], 1),
+                };
+                randomSeed += 1;
+            }
+            junimoWoods.createQuestionDialogue(
+                    Question,
+                    new Response[4]
+                    {
+                        new("Money", string.Format(Money, PurpleJunimoOptions["Money"].Amount.ToString(), PurpleJunimoOptions["Money"].OfferedItem.Name)),
+                        new("Dewdrop", string.Format(Dewdrop, PurpleJunimoOptions["Dewdrop"].Amount.ToString(), PurpleJunimoOptions["Dewdrop"].OfferedItem.Name)),
+                        new("Friendship", string.Format(Friendship, PurpleJunimoOptions["Friendship"].Amount.ToString(), PurpleJunimoOptions["Friendship"].OfferedItem.Name)),
+                                                Nothing
+
+                    }, _junimoDialogueKey);
+
+
+            return;
+
+        }
+        
+        public static bool AnswerDialogueAction_Junimoshop_Prefix(GameLocation __instance, string questionAndAnswer, string[] questionParams, ref bool __result)
+        {
+            try
+            {
+                if (!questionAndAnswer.StartsWith(_junimoDialogueKey))
+                {
+                    return true; // run original logic
+                }
+                var answer = questionAndAnswer.Split("_")[1];
+                if (answer == "No")
+                {
+                    DaJunimo.setNewDialogue($"Okie dokie, you know where to find me!  Eheh!");
+                    Game1.drawDialogue(DaJunimo);
+                    return false;
+                }
+                var checkOffer = PurpleJunimoOptions[answer];
+                if (!Game1.player.hasItemInInventory(checkOffer.OfferedItem.Id, checkOffer.Amount))
+                {
+                    DaJunimo.setNewDialogue($"You no have thing, sorry!  Check later!");
+                    Game1.drawDialogue(DaJunimo);
+                    return false;
+                }
+                Game1.player.removeItemsFromInventory(checkOffer.OfferedItem.Id, checkOffer.Amount);
+                if (answer == "Money")
+                {
+                    DaJunimo.setNewDialogue($"Oh very nice, have yellow rocks I found!  You like?");
+                    Game1.drawDialogue(DaJunimo);
+                    Game1.player.Money += 50000;
+                    return false;
+                }
+                if (answer == "Dewdrop")
+                {
+                    var itemList = Game1.objectInformation;
+                    var dewdropBerryId = itemList.First(x => x.Value.Split("/")[0] == "Dewdrop Berry");
+                    var dewdropBerry = new StardewValley.Object(dewdropBerryId.Key, 1);
+                    Game1.player.holdUpItemThenMessage(dewdropBerry);
+                    Game1.player.addItemByMenuIfNecessaryElseHoldUp(dewdropBerry);
+                    DaJunimo.setNewDialogue($"Awh okay I was gonna sleep with it, but here you go!");
+                    Game1.drawDialogue(DaJunimo);
+                    return false;
+                }
+                if (answer == "Friendship")
+                {
+                    DaJunimo.setNewDialogue($"I will tonight!  Yay!");
+                    Game1.drawDialogue(DaJunimo);
+                    Game1.player.mailReceived.Add("purpleJunimoKiss");
+                    return false;
+                }
+
+                return false; // don't run original logic
+            }
+            catch (Exception ex)
+            {
+                _monitor.Log($"Failed in {nameof(AnswerDialogueAction_Junimoshop_Prefix)}:\n{ex}", LogLevel.Error);
                 return true; // run original logic
             }
         }

--- a/StardewArchipelago/GameModifications/CodeInjections/Modded/JunimoShopInjections.cs
+++ b/StardewArchipelago/GameModifications/CodeInjections/Modded/JunimoShopInjections.cs
@@ -39,7 +39,7 @@ namespace StardewArchipelago.GameModifications.CodeInjections.Modded
             _archipelago = archipelago;
             _shopStockGenerator = shopStockGenerator;
             _stardewItemManager = stardewItemManager;
-            _junimoShopGenerator = new JunimoShopGenerator(shopStockGenerator, stardewItemManager);
+            _junimoShopGenerator = new JunimoShopGenerator(archipelago, shopStockGenerator, stardewItemManager);
         }
 
 

--- a/StardewArchipelago/GameModifications/CodeInjections/Modded/JunimoShopInjections.cs
+++ b/StardewArchipelago/GameModifications/CodeInjections/Modded/JunimoShopInjections.cs
@@ -122,19 +122,19 @@ namespace StardewArchipelago.GameModifications.CodeInjections.Modded
             var fakeStock = new Dictionary<string, int>(){
                 {"Money", 10000},
                 {"Dewdrop", 2500},
-                {"Friendship", 200 * friendsMet}
+                {"Friendship", 75 * friendsMet}
             };
             PurpleJunimoOptions = new Dictionary<string, PurpleJunimo>();
             var purpleItems = _junimoShopGenerator.PurpleItems.Keys.ToList();
             var currentWeek = (int)(Game1.stats.daysPlayed / 7) + 1;
             var random = new Random((int)Game1.uniqueIDForThisGame / 2 + currentWeek);
-            foreach (var item in fakeStock)
+            foreach (var (item, price) in fakeStock)
             {
                 var randomPurpleItem = purpleItems[random.Next(purpleItems.Count)];
                 var randomPurpleItemValue = _junimoShopGenerator.PurpleItems[randomPurpleItem];
                 var stardewItem = _stardewItemManager.GetObjectById(randomPurpleItem);
-                var purpleExchangeRate = _junimoShopGenerator.ExchangeRate(item.Value, randomPurpleItemValue);
-                PurpleJunimoOptions[item.Key] = new PurpleJunimo(){
+                var purpleExchangeRate = _junimoShopGenerator.ExchangeRate(price, randomPurpleItemValue);
+                PurpleJunimoOptions[item] = new PurpleJunimo(){
                     OfferedItem = stardewItem,
                     Amount = Math.Max(purpleExchangeRate[1] / purpleExchangeRate[0], 1),
                 };

--- a/StardewArchipelago/GameModifications/CodeInjections/Modded/JunimoShopInjections.cs
+++ b/StardewArchipelago/GameModifications/CodeInjections/Modded/JunimoShopInjections.cs
@@ -255,6 +255,7 @@ namespace StardewArchipelago.GameModifications.CodeInjections.Modded
                     }
                     Game1.player.changeFriendship(100, friend);
                 }
+                Game1.player.mailReceived.Remove("purpleJunimoKiss");
                 return;
             }
             catch (Exception ex)

--- a/StardewArchipelago/GameModifications/CodeInjections/Modded/JunimoShopInjections.cs
+++ b/StardewArchipelago/GameModifications/CodeInjections/Modded/JunimoShopInjections.cs
@@ -1,0 +1,83 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Archipelago.MultiClient.Net.Models;
+using HarmonyLib;
+using Microsoft.Xna.Framework;
+using StardewArchipelago.Archipelago;
+using StardewArchipelago.GameModifications.Modded;
+using StardewArchipelago.Items;
+using StardewArchipelago.Stardew;
+using StardewModdingAPI;
+using StardewValley;
+using StardewValley.Locations;
+using StardewValley.Menus;
+
+namespace StardewArchipelago.GameModifications.CodeInjections.Modded
+{
+    public class JunimoShopInjections
+    {
+        private static IMonitor _monitor;
+        private static IModHelper _modHelper;
+        private static ArchipelagoClient _archipelago;
+        private static ShopStockGenerator _shopStockGenerator;
+        private static StardewItemManager _stardewItemManager;
+        private static JunimoShopGenerator _junimoShopGenerator;
+
+        
+        private static readonly List<string> _junimoFirstItems = new(){
+            "Legend", "Prismatic Shard", "Ancient Seeds", "Dinosaur Egg"
+        };
+        private static readonly Dictionary<string, string> _firstItemToColor= new(){
+            {"Legend", "Blue"}, {"Prismatic Shard", "Grey"}, {"Dinosaur Egg", "Red"}, {"Ancient Seeds", "Yellow"}
+        };
+
+        public static void Initialize(IMonitor monitor, IModHelper modHelper, ArchipelagoClient archipelago, ShopStockGenerator shopStockGenerator, StardewItemManager stardewItemManager)
+        {
+            _monitor = monitor;
+            _modHelper = modHelper;
+            _archipelago = archipelago;
+            _shopStockGenerator = shopStockGenerator;
+            _stardewItemManager = stardewItemManager;
+            _junimoShopGenerator = new JunimoShopGenerator(shopStockGenerator, stardewItemManager);
+        }
+
+
+
+        private static ShopMenu _lastShopMenuUpdated = null;
+        
+        public static void Update_JunimoWoodsAPShop_Postfix(ShopMenu __instance, GameTime time)
+        {
+            try
+            {
+                // We only run this once for each menu
+                if (__instance.storeContext != "Custom_JunimoWoods")
+                {
+                    return;
+                }
+                var firstItemForSale = "";
+                if (__instance.forSale.Count == 0) // in case the shop is emptied on a second pass
+                {
+                    firstItemForSale = "";
+                }
+                else
+                {
+                    firstItemForSale = __instance.forSale.First().Name; // Fighting CP moment
+                }
+                if (!_junimoFirstItems.Contains(firstItemForSale) && _lastShopMenuUpdated == __instance)
+                {
+                    return;
+                }
+                _lastShopMenuUpdated = __instance;
+                __instance.itemPriceAndStock = _junimoShopGenerator.GetJunimoShopStock(_firstItemToColor[firstItemForSale]);
+                __instance.forSale = __instance.itemPriceAndStock.Keys.ToList();
+                return; //  run original logic
+            }
+            catch (Exception ex)
+            {
+                _monitor.Log($"Failed in {nameof(Update_JunimoWoodsAPShop_Postfix)}:\n{ex}", LogLevel.Error);
+                return; // run original logic
+            }
+        }
+    }
+}

--- a/StardewArchipelago/GameModifications/CodeInjections/Modded/JunimoShopInjections.cs
+++ b/StardewArchipelago/GameModifications/CodeInjections/Modded/JunimoShopInjections.cs
@@ -22,7 +22,7 @@ namespace StardewArchipelago.GameModifications.CodeInjections.Modded
         private static JunimoShopGenerator _junimoShopGenerator;
         private static readonly string Question = "Me love purple thing-a-ma-bobs!  Could give VERY special gift!  You want?";
         private static readonly string Money = "Weird yellow rocks for {0} {1}.";
-        private static readonly string Dewdrop = "Blue tasty under pretty tree for {0} {1}.";
+        private static readonly string Dewdrop = "Blue tasties under pretty tree for {0} {1}.";
         private static readonly string Friendship = "Kiss many people on forehead for {0} {1}.";
         private static readonly Response Nothing = new("No", "Nothing for now!");
         private static Dictionary<string, PurpleJunimo> PurpleJunimoOptions {get; set;}
@@ -120,7 +120,7 @@ namespace StardewArchipelago.GameModifications.CodeInjections.Modded
             var friendsMet = Game1.player.friendshipData.Count();
             var fakeStock = new Dictionary<string, int>(){
                 {"Money", 10000},
-                {"Dewdrop", 500},
+                {"Dewdrop", 2500},
                 {"Friendship", 200 * friendsMet}
             };
             PurpleJunimoOptions = new Dictionary<string, PurpleJunimo>();
@@ -188,7 +188,7 @@ namespace StardewArchipelago.GameModifications.CodeInjections.Modded
                 {
                     var itemList = Game1.objectInformation;
                     var dewdropBerryId = itemList.First(x => x.Value.Split("/")[0] == "Dewdrop Berry");
-                    var dewdropBerry = new StardewValley.Object(dewdropBerryId.Key, 1);
+                    var dewdropBerry = new StardewValley.Object(dewdropBerryId.Key, 5);
                     Game1.player.holdUpItemThenMessage(dewdropBerry);
                     Game1.player.addItemByMenuIfNecessaryElseHoldUp(dewdropBerry);
                     DaJunimo.setNewDialogue($"Awh okay I was gonna sleep with it, but here you go!");
@@ -198,13 +198,15 @@ namespace StardewArchipelago.GameModifications.CodeInjections.Modded
                 }
                 if (answer == "Friendship")
                 {
-                    DaJunimo.setNewDialogue($"I will tonight!  Yay!");
-                    Game1.drawDialogue(DaJunimo);
+                    
                     if (Game1.player.mailReceived.Contains("purpleJunimoKiss"))
                     {
                         DaJunimo.setNewDialogue($"You want me to kiss them TWICE?!  Wowie, but sorry!");
+                        Game1.drawDialogue(DaJunimo);
                         return false;
                     }
+                    DaJunimo.setNewDialogue($"I will tonight!  Yay!");
+                    Game1.drawDialogue(DaJunimo);
                     Game1.player.mailReceived.Add("purpleJunimoKiss");
                     Game1.player.removeItemsFromInventory(checkOffer.OfferedItem.Id, checkOffer.Amount);
                     return false;

--- a/StardewArchipelago/GameModifications/CodeInjections/Modded/JunimoShopInjections.cs
+++ b/StardewArchipelago/GameModifications/CodeInjections/Modded/JunimoShopInjections.cs
@@ -176,12 +176,12 @@ namespace StardewArchipelago.GameModifications.CodeInjections.Modded
                     Game1.drawDialogue(DaJunimo);
                     return false;
                 }
-                Game1.player.removeItemsFromInventory(checkOffer.OfferedItem.Id, checkOffer.Amount);
                 if (answer == "Money")
                 {
                     DaJunimo.setNewDialogue($"Oh very nice, have yellow rocks I found!  You like?");
                     Game1.drawDialogue(DaJunimo);
                     Game1.player.Money += 50000;
+                    Game1.player.removeItemsFromInventory(checkOffer.OfferedItem.Id, checkOffer.Amount);
                     return false;
                 }
                 if (answer == "Dewdrop")
@@ -193,13 +193,20 @@ namespace StardewArchipelago.GameModifications.CodeInjections.Modded
                     Game1.player.addItemByMenuIfNecessaryElseHoldUp(dewdropBerry);
                     DaJunimo.setNewDialogue($"Awh okay I was gonna sleep with it, but here you go!");
                     Game1.drawDialogue(DaJunimo);
+                    Game1.player.removeItemsFromInventory(checkOffer.OfferedItem.Id, checkOffer.Amount);
                     return false;
                 }
                 if (answer == "Friendship")
                 {
                     DaJunimo.setNewDialogue($"I will tonight!  Yay!");
                     Game1.drawDialogue(DaJunimo);
+                    if (Game1.player.hasOrWillReceiveMail("purpleJunimoKiss"))
+                    {
+                        DaJunimo.setNewDialogue($"You want me to kiss them TWICE?!  Wowie, but sorry!");
+                        return false;
+                    }
                     Game1.player.mailReceived.Add("purpleJunimoKiss");
+                    Game1.player.removeItemsFromInventory(checkOffer.OfferedItem.Id, checkOffer.Amount);
                     return false;
                 }
 

--- a/StardewArchipelago/GameModifications/CodeInjections/Modded/JunimoShopInjections.cs
+++ b/StardewArchipelago/GameModifications/CodeInjections/Modded/JunimoShopInjections.cs
@@ -8,6 +8,7 @@ using StardewArchipelago.Locations.CodeInjections.Vanilla.Relationship;
 using StardewArchipelago.Stardew;
 using StardewModdingAPI;
 using StardewValley;
+using StardewValley.Characters;
 using StardewValley.Menus;
 
 namespace StardewArchipelago.GameModifications.CodeInjections.Modded
@@ -231,6 +232,11 @@ namespace StardewArchipelago.GameModifications.CodeInjections.Modded
                     foreach (var friendship in Game1.player.friendshipData.Keys)
                     {
                         var friend = Game1.getCharacterFromName(friendship);
+                        var npc = friend ?? Game1.getCharacterFromName<Child>(friendship, false);
+                        if (npc == null)
+                        {
+                            continue;
+                        }
                         Game1.player.changeFriendship(100, friend);
                     }
                     Game1.player.mailReceived.Remove("purpleJunimoKiss");

--- a/StardewArchipelago/GameModifications/CodeInjections/Modded/JunimoShopInjections.cs
+++ b/StardewArchipelago/GameModifications/CodeInjections/Modded/JunimoShopInjections.cs
@@ -200,7 +200,7 @@ namespace StardewArchipelago.GameModifications.CodeInjections.Modded
                 {
                     DaJunimo.setNewDialogue($"I will tonight!  Yay!");
                     Game1.drawDialogue(DaJunimo);
-                    if (Game1.player.hasOrWillReceiveMail("purpleJunimoKiss"))
+                    if (Game1.player.mailReceived.Contains("purpleJunimoKiss"))
                     {
                         DaJunimo.setNewDialogue($"You want me to kiss them TWICE?!  Wowie, but sorry!");
                         return false;

--- a/StardewArchipelago/GameModifications/CodeInjections/Modded/JunimoShopInjections.cs
+++ b/StardewArchipelago/GameModifications/CodeInjections/Modded/JunimoShopInjections.cs
@@ -212,9 +212,8 @@ namespace StardewArchipelago.GameModifications.CodeInjections.Modded
 
         private static void PurpleJunimoDewdrop(PurpleJunimo purpleJunimoOffer)
         {
-            var itemList = Game1.objectInformation;
-            var dewdropBerryId = itemList.First(x => x.Value.Split("/")[0] == "Dewdrop Berry");
-            var dewdropBerry = new StardewValley.Object(dewdropBerryId.Key, 5);
+            var dewdropBerryId = _stardewItemManager.GetItemByName("Dewdrop Berry").Id;
+            var dewdropBerry = new StardewValley.Object(dewdropBerryId, 5);
             Game1.player.holdUpItemThenMessage(dewdropBerry);
             Game1.player.addItemByMenuIfNecessaryElseHoldUp(dewdropBerry);
             DaJunimo.setNewDialogue($"Awh okay I was gonna sleep with it, but here you go!");

--- a/StardewArchipelago/GameModifications/CodeInjections/Modded/JunimoShopInjections.cs
+++ b/StardewArchipelago/GameModifications/CodeInjections/Modded/JunimoShopInjections.cs
@@ -1,16 +1,12 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using Archipelago.MultiClient.Net.Models;
-using HarmonyLib;
 using Microsoft.Xna.Framework;
 using StardewArchipelago.Archipelago;
 using StardewArchipelago.GameModifications.Modded;
-using StardewArchipelago.Items;
 using StardewArchipelago.Stardew;
 using StardewModdingAPI;
 using StardewValley;
-using StardewValley.Locations;
 using StardewValley.Menus;
 
 namespace StardewArchipelago.GameModifications.CodeInjections.Modded
@@ -26,10 +22,20 @@ namespace StardewArchipelago.GameModifications.CodeInjections.Modded
 
         
         private static readonly List<string> _junimoFirstItems = new(){
-            "Legend", "Prismatic Shard", "Ancient Seeds", "Dinosaur Egg"
+            "Legend", "Prismatic Shard", "Ancient Seeds", "Dinosaur Egg", "Tiny Crop (stage 1)", "Super Starfruit", "Magic Bait"
+        };
+
+        private static readonly Dictionary<string, string> _junimoPhrase = new(){
+            {"Orange", "Look! Me gib tasty \nfor orange thing!" },
+            {"Red", "Give old things \nfor red gubbins!"},
+            {"Grey", "I trade rocks for \n grey what's-its!"},
+            {"Yellow", "I hab seeds, gib \nyellow gubbins!"},
+            {"Blue", "I hab fish! You \ngive blue pretty?"}
+
         };
         private static readonly Dictionary<string, string> _firstItemToColor= new(){
-            {"Legend", "Blue"}, {"Prismatic Shard", "Grey"}, {"Dinosaur Egg", "Red"}, {"Ancient Seeds", "Yellow"}
+            {"Legend", "Blue"}, {"Prismatic Shard", "Grey"}, {"Dinosaur Egg", "Red"}, {"Ancient Seeds", "Yellow"},
+            {"Tiny Crop (stage 1)", "Orange"}, {"Super Starfruit", "Purple"}, {"Magic Bait", "Purple"}
         };
 
         public static void Initialize(IMonitor monitor, IModHelper modHelper, ArchipelagoClient archipelago, ShopStockGenerator shopStockGenerator, StardewItemManager stardewItemManager, JunimoShopGenerator junimoShopGenerator)
@@ -47,14 +53,14 @@ namespace StardewArchipelago.GameModifications.CodeInjections.Modded
         private static ShopMenu _lastShopMenuUpdated = null;
         
         // public override void update(GameTime time)
-        public static void Update_JunimoWoodsAPShop_Postfix(ShopMenu __instance, GameTime time)
+        public static bool Update_JunimoWoodsAPShop_Prefix(ShopMenu __instance, GameTime time)
         {
             try
             {
                 // We only run this once for each menu
                 if (__instance.storeContext != "Custom_JunimoWoods")
                 {
-                    return;
+                    return true;
                 }
                 var firstItemForSale = "";
                 if (__instance.forSale.Count == 0) // in case the shop is emptied on a second pass
@@ -67,17 +73,27 @@ namespace StardewArchipelago.GameModifications.CodeInjections.Modded
                 }
                 if (!_junimoFirstItems.Contains(firstItemForSale) && _lastShopMenuUpdated == __instance)
                 {
-                    return;
+                    return true;
                 }
                 _lastShopMenuUpdated = __instance;
-                __instance.itemPriceAndStock = _junimoShopGenerator.GetJunimoShopStock(_firstItemToColor[firstItemForSale]);
+                var color = _firstItemToColor[firstItemForSale];
+                if (color == "Purple")
+                {
+                    // Will be worked on later
+                    /*var purpleJunimo = __instance.portraitPerson;
+                    __instance.exitThisMenuNoSound();
+                    _junimoShopGenerator.PurpleJunimoSpecialShop(purpleJunimo);*/
+                    return true;
+                }
+                __instance.itemPriceAndStock = _junimoShopGenerator.GetJunimoShopStock(color, __instance.itemPriceAndStock);
                 __instance.forSale = __instance.itemPriceAndStock.Keys.ToList();
-                return; //  run original logic
+                __instance.potraitPersonDialogue = _junimoPhrase[color];
+                return true; //  run original logic
             }
             catch (Exception ex)
             {
-                _monitor.Log($"Failed in {nameof(Update_JunimoWoodsAPShop_Postfix)}:\n{ex}", LogLevel.Error);
-                return; // run original logic
+                _monitor.Log($"Failed in {nameof(Update_JunimoWoodsAPShop_Prefix)}:\n{ex}", LogLevel.Error);
+                return true; // run original logic
             }
         }
     }

--- a/StardewArchipelago/GameModifications/CodeInjections/Modded/JunimoShopInjections.cs
+++ b/StardewArchipelago/GameModifications/CodeInjections/Modded/JunimoShopInjections.cs
@@ -154,7 +154,7 @@ namespace StardewArchipelago.GameModifications.CodeInjections.Modded
             return;
 
         }
-        
+
         public static bool AnswerDialogueAction_Junimoshop_Prefix(GameLocation __instance, string questionAndAnswer, string[] questionParams, ref bool __result)
         {
             try
@@ -179,37 +179,17 @@ namespace StardewArchipelago.GameModifications.CodeInjections.Modded
                 }
                 if (answer == "Money")
                 {
-                    DaJunimo.setNewDialogue($"Oh very nice, have yellow rocks I found!  You like?");
-                    Game1.drawDialogue(DaJunimo);
-                    Game1.player.Money += 50000;
-                    Game1.player.removeItemsFromInventory(checkOffer.OfferedItem.Id, checkOffer.Amount);
+                    PurpleJunimoMoney(checkOffer);
                     return false;
                 }
                 if (answer == "Dewdrop")
                 {
-                    var itemList = Game1.objectInformation;
-                    var dewdropBerryId = itemList.First(x => x.Value.Split("/")[0] == "Dewdrop Berry");
-                    var dewdropBerry = new StardewValley.Object(dewdropBerryId.Key, 5);
-                    Game1.player.holdUpItemThenMessage(dewdropBerry);
-                    Game1.player.addItemByMenuIfNecessaryElseHoldUp(dewdropBerry);
-                    DaJunimo.setNewDialogue($"Awh okay I was gonna sleep with it, but here you go!");
-                    Game1.drawDialogue(DaJunimo);
-                    Game1.player.removeItemsFromInventory(checkOffer.OfferedItem.Id, checkOffer.Amount);
+                    PurpleJunimoDewdrop(checkOffer);
                     return false;
                 }
                 if (answer == "Friendship")
                 {
-                    
-                    if (Game1.player.mailReceived.Contains("purpleJunimoKiss"))
-                    {
-                        DaJunimo.setNewDialogue($"You want me to kiss them TWICE?!  Wowie, but sorry!");
-                        Game1.drawDialogue(DaJunimo);
-                        return false;
-                    }
-                    DaJunimo.setNewDialogue($"I will tonight!  Yay!");
-                    Game1.drawDialogue(DaJunimo);
-                    Game1.player.mailReceived.Add("purpleJunimoKiss");
-                    Game1.player.removeItemsFromInventory(checkOffer.OfferedItem.Id, checkOffer.Amount);
+                    PurpleJunimoKiss(checkOffer);
                     return false;
                 }
 
@@ -220,6 +200,40 @@ namespace StardewArchipelago.GameModifications.CodeInjections.Modded
                 _monitor.Log($"Failed in {nameof(AnswerDialogueAction_Junimoshop_Prefix)}:\n{ex}", LogLevel.Error);
                 return true; // run original logic
             }
+        }
+
+        private static void PurpleJunimoMoney(PurpleJunimo purpleJunimoOffer)
+        {
+            DaJunimo.setNewDialogue($"Oh very nice, have yellow rocks I found!  You like?");
+            Game1.drawDialogue(DaJunimo);
+            Game1.player.Money += 50000;
+            Game1.player.removeItemsFromInventory(purpleJunimoOffer.OfferedItem.Id, purpleJunimoOffer.Amount);
+        }
+
+        private static void PurpleJunimoDewdrop(PurpleJunimo purpleJunimoOffer)
+        {
+            var itemList = Game1.objectInformation;
+            var dewdropBerryId = itemList.First(x => x.Value.Split("/")[0] == "Dewdrop Berry");
+            var dewdropBerry = new StardewValley.Object(dewdropBerryId.Key, 5);
+            Game1.player.holdUpItemThenMessage(dewdropBerry);
+            Game1.player.addItemByMenuIfNecessaryElseHoldUp(dewdropBerry);
+            DaJunimo.setNewDialogue($"Awh okay I was gonna sleep with it, but here you go!");
+            Game1.drawDialogue(DaJunimo);
+            Game1.player.removeItemsFromInventory(purpleJunimoOffer.OfferedItem.Id, purpleJunimoOffer.Amount);
+        }
+
+        private static void PurpleJunimoKiss(PurpleJunimo purpleJunimoOffer)
+        {
+            if (Game1.player.mailReceived.Contains("purpleJunimoKiss"))
+                    {
+                        DaJunimo.setNewDialogue($"You want me to kiss them TWICE?!  Wowie, but sorry!");
+                        Game1.drawDialogue(DaJunimo);
+                        return;
+                    }
+                    DaJunimo.setNewDialogue($"I will tonight!  Yay!");
+                    Game1.drawDialogue(DaJunimo);
+                    Game1.player.mailReceived.Add("purpleJunimoKiss");
+                    Game1.player.removeItemsFromInventory(purpleJunimoOffer.OfferedItem.Id, purpleJunimoOffer.Amount);
         }
 
         // public void resetFriendshipsForNewDay()

--- a/StardewArchipelago/GameModifications/CodeInjections/Modded/JunimoShopInjections.cs
+++ b/StardewArchipelago/GameModifications/CodeInjections/Modded/JunimoShopInjections.cs
@@ -46,6 +46,7 @@ namespace StardewArchipelago.GameModifications.CodeInjections.Modded
 
         private static ShopMenu _lastShopMenuUpdated = null;
         
+        // public override void update(GameTime time)
         public static void Update_JunimoWoodsAPShop_Postfix(ShopMenu __instance, GameTime time)
         {
             try

--- a/StardewArchipelago/GameModifications/CodeInjections/Modded/JunimoShopInjections.cs
+++ b/StardewArchipelago/GameModifications/CodeInjections/Modded/JunimoShopInjections.cs
@@ -125,19 +125,19 @@ namespace StardewArchipelago.GameModifications.CodeInjections.Modded
                 {"Friendship", 200 * friendsMet}
             };
             PurpleJunimoOptions = new Dictionary<string, PurpleJunimo>();
-            var randomSeed = 0;
+            var purpleItems = _junimoShopGenerator.PurpleItems.Keys.ToList();
+            var currentWeek = (int)(Game1.stats.daysPlayed / 7) + 1;
+            var random = new Random((int)Game1.uniqueIDForThisGame / 2 + currentWeek);
             foreach (var item in fakeStock)
             {
-                var currentMonth = (int)(Game1.stats.daysPlayed / 28) + 1;
-                var random = new Random((int)Game1.uniqueIDForThisGame / 2 + currentMonth + randomSeed);
-                var itemToTrade = _junimoShopGenerator.PurpleItems.ElementAt(random.Next(_junimoShopGenerator.PurpleItems.Count));
-                var stardewItem = _stardewItemManager.GetObjectById(itemToTrade.Key);
-                var itemToTradeTotal = JunimoShopGenerator.ExchangeRate(item.Value, itemToTrade.Value);
+                var randomPurpleItem = purpleItems[random.Next(purpleItems.Count)];
+                var randomPurpleItemValue = _junimoShopGenerator.PurpleItems[randomPurpleItem];
+                var stardewItem = _stardewItemManager.GetObjectById(randomPurpleItem);
+                var purpleExchangeRate = _junimoShopGenerator.ExchangeRate(item.Value, randomPurpleItemValue);
                 PurpleJunimoOptions[item.Key] = new PurpleJunimo(){
                     OfferedItem = stardewItem,
-                    Amount = Math.Max(itemToTradeTotal[1] / itemToTradeTotal[0], 1),
+                    Amount = Math.Max(purpleExchangeRate[1] / purpleExchangeRate[0], 1),
                 };
-                randomSeed += 1;
             }
             junimoWoods.createQuestionDialogue(
                     Question,

--- a/StardewArchipelago/GameModifications/CodeInjections/Modded/JunimoShopInjections.cs
+++ b/StardewArchipelago/GameModifications/CodeInjections/Modded/JunimoShopInjections.cs
@@ -36,7 +36,7 @@ namespace StardewArchipelago.GameModifications.CodeInjections.Modded
         };
 
         private static readonly Dictionary<string, string> _junimoPhrase = new(){
-            {"Orange", "Look! Me gib tasty \nfor orange thing!" },
+            {"Orange", "Look! Me gib pretty \nfor orange thing!" },
             {"Red", "Give old things \nfor red gubbins!"},
             {"Grey", "I trade rocks for \n grey what's-its!"},
             {"Yellow", "I hab seeds, gib \nyellow gubbins!"},

--- a/StardewArchipelago/GameModifications/CodeInjections/Modded/JunimoShopInjections.cs
+++ b/StardewArchipelago/GameModifications/CodeInjections/Modded/JunimoShopInjections.cs
@@ -32,14 +32,14 @@ namespace StardewArchipelago.GameModifications.CodeInjections.Modded
             {"Legend", "Blue"}, {"Prismatic Shard", "Grey"}, {"Dinosaur Egg", "Red"}, {"Ancient Seeds", "Yellow"}
         };
 
-        public static void Initialize(IMonitor monitor, IModHelper modHelper, ArchipelagoClient archipelago, ShopStockGenerator shopStockGenerator, StardewItemManager stardewItemManager)
+        public static void Initialize(IMonitor monitor, IModHelper modHelper, ArchipelagoClient archipelago, ShopStockGenerator shopStockGenerator, StardewItemManager stardewItemManager, JunimoShopGenerator junimoShopGenerator)
         {
             _monitor = monitor;
             _modHelper = modHelper;
             _archipelago = archipelago;
             _shopStockGenerator = shopStockGenerator;
             _stardewItemManager = stardewItemManager;
-            _junimoShopGenerator = new JunimoShopGenerator(archipelago, shopStockGenerator, stardewItemManager);
+            _junimoShopGenerator = junimoShopGenerator;
         }
 
 

--- a/StardewArchipelago/GameModifications/CodeInjections/Modded/JunimoShopInjections.cs
+++ b/StardewArchipelago/GameModifications/CodeInjections/Modded/JunimoShopInjections.cs
@@ -109,7 +109,7 @@ namespace StardewArchipelago.GameModifications.CodeInjections.Modded
             }
         }
 
-                private class PurpleJunimo
+        private class PurpleJunimo
         {
             public StardewItem OfferedItem {get; set;}
             public int Amount {get; set;}

--- a/StardewArchipelago/GameModifications/CodeInjections/Modded/JunimoShopInjections.cs
+++ b/StardewArchipelago/GameModifications/CodeInjections/Modded/JunimoShopInjections.cs
@@ -26,11 +26,11 @@ namespace StardewArchipelago.GameModifications.CodeInjections.Modded
         private static readonly string Dewdrop = "Blue tasties under pretty tree for {0} {1}.";
         private static readonly string Friendship = "Kiss many people on forehead for {0} {1}.";
         private static readonly Response Nothing = new("No", "Nothing for now!");
-        private static Dictionary<string, PurpleJunimo> PurpleJunimoOptions {get; set;}
+        private static Dictionary<string, PurpleJunimo> PurpleJunimoOptions { get; set; }
         private static NPC DaJunimo = new();
         private static readonly string _junimoDialogueKey = "PurpleJunimoVendor";
 
-        
+
         private static readonly List<string> _junimoFirstItems = new(){
             "Legend", "Prismatic Shard", "Ancient Seeds", "Dinosaur Egg", "Tiny Crop (stage 1)", "Super Starfruit", "Magic Bait"
         };
@@ -43,7 +43,7 @@ namespace StardewArchipelago.GameModifications.CodeInjections.Modded
             {"Blue", "I hab fish! You \ngive blue pretty?"}
 
         };
-        private static readonly Dictionary<string, string> _firstItemToColor= new(){
+        private static readonly Dictionary<string, string> _firstItemToColor = new(){
             {"Legend", "Blue"}, {"Prismatic Shard", "Grey"}, {"Dinosaur Egg", "Red"}, {"Ancient Seeds", "Yellow"},
             {"Tiny Crop (stage 1)", "Orange"}, {"Super Starfruit", "Purple"}, {"Magic Bait", "Purple"}
         };
@@ -61,7 +61,7 @@ namespace StardewArchipelago.GameModifications.CodeInjections.Modded
 
 
         private static ShopMenu _lastShopMenuUpdated = null;
-        
+
         // public override void update(GameTime time)
         public static bool Update_JunimoWoodsAPShop_Prefix(ShopMenu __instance, GameTime time)
         {
@@ -111,8 +111,8 @@ namespace StardewArchipelago.GameModifications.CodeInjections.Modded
 
         private class PurpleJunimo
         {
-            public StardewItem OfferedItem {get; set;}
-            public int Amount {get; set;}
+            public StardewItem OfferedItem { get; set; }
+            public int Amount { get; set; }
         }
 
         public static void PurpleJunimoSpecialShop()
@@ -125,16 +125,17 @@ namespace StardewArchipelago.GameModifications.CodeInjections.Modded
                 {"Friendship", 75 * friendsMet}
             };
             PurpleJunimoOptions = new Dictionary<string, PurpleJunimo>();
-            var purpleItems = _junimoShopGenerator.PurpleItems.Keys.ToList();
+            var purpleItems = _junimoShopGenerator.PurpleItems.Keys.ToArray();
             var currentWeek = (int)(Game1.stats.daysPlayed / 7) + 1;
             var random = new Random((int)Game1.uniqueIDForThisGame / 2 + currentWeek);
             foreach (var (item, price) in fakeStock)
             {
-                var randomPurpleItem = purpleItems[random.Next(purpleItems.Count)];
+                var randomPurpleItem = purpleItems[random.Next(purpleItems.Length)];
                 var randomPurpleItemValue = _junimoShopGenerator.PurpleItems[randomPurpleItem];
                 var stardewItem = _stardewItemManager.GetObjectById(randomPurpleItem);
                 var purpleExchangeRate = _junimoShopGenerator.ExchangeRate(price, randomPurpleItemValue);
-                PurpleJunimoOptions[item] = new PurpleJunimo(){
+                PurpleJunimoOptions[item] = new PurpleJunimo()
+                {
                     OfferedItem = stardewItem,
                     Amount = Math.Max(purpleExchangeRate[1] / purpleExchangeRate[0], 1),
                 };
@@ -224,15 +225,15 @@ namespace StardewArchipelago.GameModifications.CodeInjections.Modded
         private static void PurpleJunimoKiss(PurpleJunimo purpleJunimoOffer)
         {
             if (Game1.player.mailReceived.Contains("purpleJunimoKiss"))
-                    {
-                        DaJunimo.setNewDialogue($"You want me to kiss them TWICE?!  Wowie, but sorry!");
-                        Game1.drawDialogue(DaJunimo);
-                        return;
-                    }
-                    DaJunimo.setNewDialogue($"I will tonight!  Yay!");
-                    Game1.drawDialogue(DaJunimo);
-                    Game1.player.mailReceived.Add("purpleJunimoKiss");
-                    Game1.player.removeItemsFromInventory(purpleJunimoOffer.OfferedItem.Id, purpleJunimoOffer.Amount);
+            {
+                DaJunimo.setNewDialogue($"You want me to kiss them TWICE?!  Wowie, but sorry!");
+                Game1.drawDialogue(DaJunimo);
+                return;
+            }
+            DaJunimo.setNewDialogue($"I will tonight!  Yay!");
+            Game1.drawDialogue(DaJunimo);
+            Game1.player.mailReceived.Add("purpleJunimoKiss");
+            Game1.player.removeItemsFromInventory(purpleJunimoOffer.OfferedItem.Id, purpleJunimoOffer.Amount);
         }
 
         // public void resetFriendshipsForNewDay()
@@ -240,26 +241,26 @@ namespace StardewArchipelago.GameModifications.CodeInjections.Modded
         {
             try
             {
-                if (Game1.player.mailReceived.Contains("purpleJunimoKiss"))
+                if (!Game1.player.mailReceived.Contains("purpleJunimoKiss"))
                 {
-                    foreach (var friendship in Game1.player.friendshipData.Keys)
-                    {
-                        var friend = Game1.getCharacterFromName(friendship);
-                        var npc = friend ?? Game1.getCharacterFromName<Child>(friendship, false);
-                        if (npc == null)
-                        {
-                            continue;
-                        }
-                        Game1.player.changeFriendship(100, friend);
-                    }
-                    Game1.player.mailReceived.Remove("purpleJunimoKiss");
+                    return;
                 }
-                return; // don't run original logic
+                foreach (var friendship in Game1.player.friendshipData.Keys)
+                {
+                    var friend = Game1.getCharacterFromName(friendship);
+                    var npc = friend ?? Game1.getCharacterFromName<Child>(friendship, false);
+                    if (npc == null)
+                    {
+                        continue;
+                    }
+                    Game1.player.changeFriendship(100, friend);
+                }
+                return;
             }
             catch (Exception ex)
             {
                 _monitor.Log($"Failed in {nameof(ResetFriendshipsForNewDay_KissForeheads_Postfix)}:\n{ex}", LogLevel.Error);
-                return; // run original logic
+                return;
             }
         }
     }

--- a/StardewArchipelago/GameModifications/Modded/JunimoShopGenerator.cs
+++ b/StardewArchipelago/GameModifications/Modded/JunimoShopGenerator.cs
@@ -195,7 +195,7 @@ namespace StardewArchipelago.GameModifications.Modded
             }
 
             var random = new Random((int)Game1.stats.DaysPlayed + (int)Game1.uniqueIDForThisGame / 2 + itemId);
-            if (random.NextDouble() < 0.7)
+            if (random.NextDouble() < 0.4)
             {
                 return;
             }

--- a/StardewArchipelago/GameModifications/Modded/JunimoShopGenerator.cs
+++ b/StardewArchipelago/GameModifications/Modded/JunimoShopGenerator.cs
@@ -269,22 +269,10 @@ namespace StardewArchipelago.GameModifications.Modded
 
         private Dictionary<ISalable, int[]> GenerateOrangeJunimoStock(Dictionary<ISalable, int[]> stock, Dictionary<ISalable, int[]> oldStock)
         {
-            var random = new Random((int)Game1.stats.DaysPlayed + (int)Game1.uniqueIDForThisGame / 2 + Game1.currentGameTime.ElapsedGameTime.Seconds);
-            var totalDecor = oldStock.Keys.ToArray();
-            var dailyDecor = new List<ISalable>();
-            for (var i = 0; i < 2; i++) // Allow these to still exist; just not all of them all the time
-            {
-                dailyDecor.Add(totalDecor[random.Next(totalDecor.Length)]);
-            }
-            foreach (var item in dailyDecor)
+            foreach (var (item, value) in oldStock)
             {
                 var shopItem = _stardewItemManager.GetItemByName(item.Name);
-                AddToJunimoStock(stock, shopItem, "Orange", "BigCraftable", 0, item.salePrice());
-            }
-            var cookedRecipes = Game1.player.recipesCooked.Keys;
-            foreach (var recipe in cookedRecipes)
-            {
-                AddToJunimoStock(stock, recipe, "Orange", false);
+                AddToJunimoStock(stock, shopItem, "Orange", "BigCraftable", 0, value[0]);
             }
             return stock;
         }
@@ -478,7 +466,7 @@ namespace StardewArchipelago.GameModifications.Modded
             AddToJunimoStock(stock, ShopItemIds.GRAPE_STARTER, "Yellow", true, fall);
             AddToJunimoStock(stock, ShopItemIds.ARTICHOKE_SEEDS, "Yellow", true, fall);
         }
-        
+
         private void AddSaplingsToShop(Dictionary<ISalable, int[]> stock)
         {
             AddToJunimoStock(stock, ShopItemIds.CHERRY_SAPLING, "Yellow", true);

--- a/StardewArchipelago/GameModifications/Modded/JunimoShopGenerator.cs
+++ b/StardewArchipelago/GameModifications/Modded/JunimoShopGenerator.cs
@@ -503,11 +503,8 @@ namespace StardewArchipelago.GameModifications.Modded
                 return;
             }
 
-            var voidMintIdentifier = "1 2 2 3 2/spring summer fall/109/"; //Done as modded seeds have variable ID but use ID in dictionary
-            var vileAncientIdentifier = "2 7 7 7 5/spring summer fall/108/";
-            var cropList = Game1.content.Load<Dictionary<int, string>>("Data\\Crops");
-            var voidMintSeeds = cropList.FirstOrDefault(x => x.Value.Contains(voidMintIdentifier)).Key;
-            var vileAncientFruitSeeds = cropList.FirstOrDefault(x => x.Value.Contains(vileAncientIdentifier)).Key;
+            var voidMintSeeds = _stardewItemManager.GetItemByName("Void Mint Seeds").Id;
+            var vileAncientFruitSeeds = _stardewItemManager.GetItemByName("Vile Ancient Fruit Seeds").Id;
             AddToJunimoStock(stock, voidMintSeeds, "Yellow", true);
             AddToJunimoStock(stock, vileAncientFruitSeeds, "Yellow", true);
         }

--- a/StardewArchipelago/GameModifications/Modded/JunimoShopGenerator.cs
+++ b/StardewArchipelago/GameModifications/Modded/JunimoShopGenerator.cs
@@ -24,7 +24,7 @@ namespace StardewArchipelago.GameModifications.Modded
         private PersistentStock GreyPersistentStock { get; }
         private PersistentStock YellowPersistentStock { get; }
         private PersistentStock RedPersistentStock { get; }
-        private PersistentStock OrangePersistentStock {get; }
+        private PersistentStock OrangePersistentStock { get; }
         private static Dictionary<string, JunimoVendor> JunimoVendors { get; set; }
         private Dictionary<int, int> BlueItems { get; set; }
         private static readonly List<string> BlueColors = new()
@@ -52,20 +52,20 @@ namespace StardewArchipelago.GameModifications.Modded
         {
             "color_orange", "color_dark_orange", "color_dark_brown", "color_brown", "color_copper"
         };
-        public Dictionary<int, int> PurpleItems {get; set; }
+        public Dictionary<int, int> PurpleItems { get; set; }
         private static readonly List<string> PurpleColors = new()
         {
             "color_purple", "color_dark_purple", "color_dark_pink", "color_pale_violet_red", "color_iridium"
         };
-        public Dictionary<StardewItem, int> BerryItems {get; set; }
-        private static readonly string[] spring = new string[]{"spring"};
-        private static readonly string[] summer = new string[]{"summer"};
-        private static readonly string[] fall = new string[]{"fall"};
+        public Dictionary<StardewItem, int> BerryItems { get; set; }
+        private static readonly string[] spring = new string[] { "spring" };
+        private static readonly string[] summer = new string[] { "summer" };
+        private static readonly string[] fall = new string[] { "fall" };
 
         private class JunimoVendor
         {
-            public PersistentStock JunimoPersistentStock {get; private set;}
-            public Dictionary<int, int> ColorItems {get; private set;}
+            public PersistentStock JunimoPersistentStock { get; private set; }
+            public Dictionary<int, int> ColorItems { get; private set; }
 
             public JunimoVendor(PersistentStock junimoPersistentStock, Dictionary<int, int> colorItems)
             {
@@ -92,7 +92,7 @@ namespace StardewArchipelago.GameModifications.Modded
             var redVendor = new JunimoVendor(RedPersistentStock, RedItems);
             var orangeVendor = new JunimoVendor(OrangePersistentStock, OrangeItems);
             JunimoVendors = new Dictionary<string, JunimoVendor>(){
-                {"Blue", blueVendor}, {"Yellow", yellowVendor}, {"Grey", greyVendor}, {"Red", redVendor}, {"Orange", orangeVendor}, 
+                {"Blue", blueVendor}, {"Yellow", yellowVendor}, {"Grey", greyVendor}, {"Red", redVendor}, {"Orange", orangeVendor},
             };
         }
 
@@ -123,7 +123,6 @@ namespace StardewArchipelago.GameModifications.Modded
                 }
                 if (IsColor(itemContext, "blue") && !itemContext.Contains("fish") && !itemContext.Contains("marine"))
                 {
-                    
                     BlueItems[item.Id] = item.SellPrice;
                     continue;
                 }
@@ -271,13 +270,13 @@ namespace StardewArchipelago.GameModifications.Modded
         private Dictionary<ISalable, int[]> GenerateOrangeJunimoStock(Dictionary<ISalable, int[]> stock, Dictionary<ISalable, int[]> oldStock)
         {
             var random = new Random((int)Game1.stats.DaysPlayed + (int)Game1.uniqueIDForThisGame / 2 + Game1.currentGameTime.ElapsedGameTime.Seconds);
-            var totalDecor = oldStock.Keys.ToList();
+            var totalDecor = oldStock.Keys.ToArray();
             var dailyDecor = new List<ISalable>();
             for (var i = 0; i < 2; i++) // Allow these to still exist; just not all of them all the time
             {
-                dailyDecor.Add(totalDecor[random.Next(oldStock.Count)]);
+                dailyDecor.Add(totalDecor[random.Next(totalDecor.Length)]);
             }
-            foreach (var item in dailyDecor) 
+            foreach (var item in dailyDecor)
             {
                 var shopItem = _stardewItemManager.GetItemByName(item.Name);
                 AddToJunimoStock(stock, shopItem, "Orange", "BigCraftable", 0, item.salePrice());
@@ -298,13 +297,12 @@ namespace StardewArchipelago.GameModifications.Modded
             double failRate = 0.4,
             int uniquePrice = -1)
         {
-            
             var itemName = stardewItem.Name;
             var item = new StardewValley.Object(Vector2.Zero, stardewItem.Id, 1);
             if (category == "BigCraftable")
-                {
-                    item = new StardewValley.Object(Vector2.Zero, stardewItem.Id);
-                }
+            {
+                item = new StardewValley.Object(Vector2.Zero, stardewItem.Id);
+            }
             var random = new Random((int)Game1.stats.DaysPlayed + (int)Game1.uniqueIDForThisGame / 2 + stardewItem.Id);
             if (random.NextDouble() < failRate)
             {
@@ -343,7 +341,7 @@ namespace StardewArchipelago.GameModifications.Modded
             string[] itemSeason = null)
         {
             var item = _stardewItemManager.GetObjectById(itemId);
-            if (isSeed == true && _archipelago.SlotData.Cropsanity == Cropsanity.Shuffled && !_archipelago.HasReceivedItem(item.Name))
+            if (isSeed && _archipelago.SlotData.Cropsanity == Cropsanity.Shuffled && !_archipelago.HasReceivedItem(item.Name))
             {
                 return;
             }
@@ -357,13 +355,13 @@ namespace StardewArchipelago.GameModifications.Modded
         public int[] ExchangeRate(int soldItemValue, int requestedItemValue)
         {
             if (IsOnePriceAMultipleOfOther(soldItemValue, requestedItemValue, out var exchangeRate))
-                {
-                    return exchangeRate;
-                }
+            {
+                return exchangeRate;
+            }
             var greatestCommonDivisor = GreatestCommonDivisor(soldItemValue, requestedItemValue);
             var leastCommonMultiple = soldItemValue * requestedItemValue / greatestCommonDivisor;
-            var soldItemCount = leastCommonMultiple/soldItemValue;
-            var requestedItemCount = leastCommonMultiple/requestedItemValue;
+            var soldItemCount = leastCommonMultiple / soldItemValue;
+            var requestedItemCount = leastCommonMultiple / requestedItemValue;
 
             var applesDiscount = GiveApplesFriendshipDiscount(soldItemCount, requestedItemCount);
             soldItemCount = applesDiscount[0];
@@ -371,24 +369,23 @@ namespace StardewArchipelago.GameModifications.Modded
 
             var lowestCount = 5; // This is for us to change if we want to move this value around easily in testing
             var finalCounts = MakeMinimalCountBelowGivenCount(soldItemCount, requestedItemCount, lowestCount);
-            
             return finalCounts;
         }
 
         private bool IsOnePriceAMultipleOfOther(int soldItemValue, int requestedItemValue, out int[] exchangeRate)
         {
             exchangeRate = null;
-            if (soldItemValue > requestedItemValue && soldItemValue % requestedItemValue == 0)    
-                {
-                    exchangeRate = new int[2]{1, soldItemValue / requestedItemValue};
-                    return true;
-                }
-            if (soldItemValue <= requestedItemValue &&  requestedItemValue % soldItemValue == 0)
-                {
-                    exchangeRate = new int[2]{requestedItemValue / soldItemValue, 1};
-                    return true;
-                }
-                
+            if (soldItemValue > requestedItemValue && soldItemValue % requestedItemValue == 0)
+            {
+                exchangeRate = new int[2] { 1, soldItemValue / requestedItemValue };
+                return true;
+            }
+            if (soldItemValue <= requestedItemValue && requestedItemValue % soldItemValue == 0)
+            {
+                exchangeRate = new int[2] { requestedItemValue / soldItemValue, 1 };
+                return true;
+            }
+
             return false;
         }
 
@@ -396,18 +393,18 @@ namespace StardewArchipelago.GameModifications.Modded
         {
             var applesHearts = 0;
             if (Game1.player.friendshipData.ContainsKey("Apples"))
-                {
-                    applesHearts = Game1.player.friendshipData["Apples"].Points / 250; // Get discount from being friends with Apples
-                }
+            {
+                applesHearts = Game1.player.friendshipData["Apples"].Points / 250; // Get discount from being friends with Apples
+            }
             if (requestedItemCount == 1)
-                {
-                    soldItemCount = (int)(soldItemCount * (1 + applesHearts * 0.05f));
-                }
+            {
+                soldItemCount = (int)(soldItemCount * (1 + applesHearts * 0.05f));
+            }
             else
-                {
-                    requestedItemCount = (int)Math.Max(1, requestedItemCount * (1 - applesHearts * 0.05f));
-                }
-            return new int[2]{soldItemCount, requestedItemCount};
+            {
+                requestedItemCount = (int)Math.Max(1, requestedItemCount * (1 - applesHearts * 0.05f));
+            }
+            return new int[2] { soldItemCount, requestedItemCount };
 
         }
 
@@ -422,7 +419,7 @@ namespace StardewArchipelago.GameModifications.Modded
                 soldItemCount /= greatestCommonDivisor;
                 requestedItemCount /= greatestCommonDivisor;
             }
-            return new int[2]{soldItemCount, requestedItemCount};
+            return new int[2] { soldItemCount, requestedItemCount };
         }
 
         private void AddSeedsToYellowStock(Dictionary<ISalable, int[]> stock)
@@ -481,6 +478,7 @@ namespace StardewArchipelago.GameModifications.Modded
             AddToJunimoStock(stock, ShopItemIds.GRAPE_STARTER, "Yellow", true, fall);
             AddToJunimoStock(stock, ShopItemIds.ARTICHOKE_SEEDS, "Yellow", true, fall);
         }
+        
         private void AddSaplingsToShop(Dictionary<ISalable, int[]> stock)
         {
             AddToJunimoStock(stock, ShopItemIds.CHERRY_SAPLING, "Yellow", true);
@@ -511,7 +509,7 @@ namespace StardewArchipelago.GameModifications.Modded
 
         public int ValueOfOneItemWithWeight(int[] offerRatio, double weight)
         {
-            return (int) Math.Pow(offerRatio[1] / offerRatio[0], weight);
+            return (int)Math.Pow(offerRatio[1] / offerRatio[0], weight);
         }
 
         private static int GreatestCommonDivisor(int firstValue, int secondValue) //Seemingly no basic method outside of BigInteger?
@@ -519,13 +517,9 @@ namespace StardewArchipelago.GameModifications.Modded
             var largestValue = Math.Max(firstValue, secondValue);
             var lowestValue = Math.Min(firstValue, secondValue);
             var remainder = largestValue % lowestValue;
-            if ( remainder == 0)
+            if (remainder == 0)
             {
-                if (firstValue > secondValue)
-                {
-                    return secondValue;
-                }
-                return firstValue;
+                return lowestValue;
             }
             while (remainder != 0)
             {

--- a/StardewArchipelago/GameModifications/Modded/JunimoShopGenerator.cs
+++ b/StardewArchipelago/GameModifications/Modded/JunimoShopGenerator.cs
@@ -200,11 +200,7 @@ namespace StardewArchipelago.GameModifications.Modded
             }
             var itemToTrade = JunimoVendors[color].ColorItems.ElementAt(random.Next(JunimoVendors[color].ColorItems.Count));
             var itemToTradeTotal = ExchangeRate(item, itemToTrade.Value);
-
-            if (Game1.player.hasCompletedCommunityCenter())
-            {
-                itemToTradeTotal[1] = Math.Min(1, 4* itemToTradeTotal[1] / 5);
-            }
+            
             item.Stack = itemToTradeTotal[0];
             
             stock.Add(item, new int[4]
@@ -227,6 +223,15 @@ namespace StardewArchipelago.GameModifications.Modded
             var lcm = soldItem.salePrice() * wantedItem / gcd;
             var requestCount = lcm/soldItem.salePrice();
             var offerCount = lcm/wantedItem;
+
+            var applesHearts = 0;
+            if (Game1.player.friendshipData.ContainsKey("Apples"))
+                applesHearts = Game1.player.friendshipData["Apples"].Points / 250; // Get discount from being friends with Apples
+            if (offerCount == 1)
+                requestCount = (int) Math.Min(1, requestCount * (1 + applesHearts * 0.05f));
+            else
+                offerCount = (int) Math.Min(1, offerCount * (1 - applesHearts * 0.05f));
+
             var lowestTrade = 5; // This is for us to change if we want to move this value around easily in testing
             if (Math.Min(requestCount, offerCount) > lowestTrade)
             {

--- a/StardewArchipelago/GameModifications/Modded/JunimoShopGenerator.cs
+++ b/StardewArchipelago/GameModifications/Modded/JunimoShopGenerator.cs
@@ -25,7 +25,7 @@ namespace StardewArchipelago.GameModifications.Modded
         private Dictionary<int, int> BlueItems { get; set; }
         private static readonly List<string> BlueColors = new()
         {
-            "color_blue", "color_aquamarine", "color_dark_blue", "color_cyan", "color_light_cyan"
+            "color_blue", "color_aquamarine", "color_dark_blue", "color_cyan", "color_light_cyan", "color_dark_cyan"
         };
         private Dictionary<int, int> GreyItems { get; set; }
         private static readonly List<string> GreyColors = new()
@@ -35,12 +35,12 @@ namespace StardewArchipelago.GameModifications.Modded
         private Dictionary<int, int> RedItems { get; set; }
         private static readonly List<string> RedColors = new()
         {
-            "color_red", "color_pink", "color_dark_pink"
+            "color_red", "color_pink", "color_dark_pink", "color_salmon"
         };
         private Dictionary<int, int> YellowItems { get; set; }
         private static readonly List<string> YellowColors = new()
         {
-            "color_yellow", "color_gold", "color_sand"
+            "color_yellow", "color_gold", "color_sand", "color_dark_yellow"
         };
         private static readonly string[] spring = new string[]{"spring"};
         private static readonly string[] summer = new string[]{"summer"};

--- a/StardewArchipelago/GameModifications/Modded/JunimoShopGenerator.cs
+++ b/StardewArchipelago/GameModifications/Modded/JunimoShopGenerator.cs
@@ -52,7 +52,7 @@ namespace StardewArchipelago.GameModifications.Modded
         {
             "color_orange", "color_dark_orange", "color_dark_brown", "color_brown", "color_copper"
         };
-        private Dictionary<int, int> PurpleItems {get; set; }
+        public Dictionary<int, int> PurpleItems {get; set; }
         private static readonly List<string> PurpleColors = new()
         {
             "color_purple", "color_dark_purple", "color_dark_pink", "color_pale_violet_red", "color_iridium"
@@ -92,7 +92,7 @@ namespace StardewArchipelago.GameModifications.Modded
             var redVendor = new JunimoVendor(RedPersistentStock, RedItems);
             var orangeVendor = new JunimoVendor(OrangePersistentStock, OrangeItems);
             JunimoVendors = new Dictionary<string, JunimoVendor>(){
-                {"Blue", blueVendor}, {"Yellow", yellowVendor}, {"Grey", greyVendor}, {"Red", redVendor}, {"Orange", orangeVendor}
+                {"Blue", blueVendor}, {"Yellow", yellowVendor}, {"Grey", greyVendor}, {"Red", redVendor}, {"Orange", orangeVendor}, 
             };
         }
 
@@ -147,7 +147,7 @@ namespace StardewArchipelago.GameModifications.Modded
                     OrangeItems[item.Id] = item.SellPrice;
                     continue;
                 }
-                if (IsColor(itemContext, "purple"))
+                if (IsColor(itemContext, "purple") && type.Contains("Basic"))
                 {
                     PurpleItems[item.Id] = item.SellPrice;
                     continue;
@@ -289,37 +289,6 @@ namespace StardewArchipelago.GameModifications.Modded
             return stock;
         }
 
-        private static class PurpleJunimo
-        {
-            public static readonly string Question = "Me love purple thing-a-ma-bobs!  Could give VERY special gift!  You want?";
-            public static readonly Response Money = new("Weird yellow rocks?", "Purchase ({0} {1})");
-            public static readonly int MoneyAmount = 100000;
-            public static readonly Response Dewdrop = new("Blue tasty under pretty tree!", "Purchase ({0} {1})");
-            public static readonly Response Friendship = new("Kiss many people on forehead!", "Purchase ({0} {1})");
-            public static readonly int FriendshipValuePer = 200;
-            public static readonly int FriendshipAmount = 50;
-            public static readonly Response Deathlink = new("Help everyone sleep tight...?", "Purchase ({0} {1})");
-            public static readonly Response Nothing = new("No", "Not Now");
-        }
-
-        public void PurpleJunimoSpecialShop(NPC junimo)
-        {
-            var junimoWoods = junimo.currentLocation;
-            junimoWoods.createQuestionDialogue(
-                    PurpleJunimo.Question,
-                    new Response[5]
-                    {
-                        PurpleJunimo.Money,
-                        PurpleJunimo.Dewdrop,
-                        PurpleJunimo.Friendship,
-                        PurpleJunimo.Deathlink,
-                        PurpleJunimo.Nothing
-                    }, "PurpleJunimoVendor");
-
-            return;
-
-        }
-
         private void AddToJunimoStock(
             Dictionary<ISalable, int[]> stock,
             StardewItem stardewItem,
@@ -353,13 +322,13 @@ namespace StardewArchipelago.GameModifications.Modded
             });
         }
 
-        // May be useful one day, just not now
         /*private void AddToJunimoStock(
             Dictionary<ISalable, int[]> stock,
             string itemName,
-            string color)
+            string color,
+            int uniquePrice)
         {
-            AddToJunimoStock(stock, _stardewItemManager.GetItemByName(itemName), color, null);
+            AddToJunimoStock(stock, _stardewItemManager.GetItemByName(itemName), color, null, 0.4, uniquePrice);
         }*/
 
         private void AddToJunimoStock(

--- a/StardewArchipelago/GameModifications/Modded/JunimoShopGenerator.cs
+++ b/StardewArchipelago/GameModifications/Modded/JunimoShopGenerator.cs
@@ -195,7 +195,7 @@ namespace StardewArchipelago.GameModifications.Modded
             }
 
             var random = new Random((int)Game1.stats.DaysPlayed + (int)Game1.uniqueIDForThisGame / 2 + itemId);
-            if (random.NextDouble() < 0.4)
+            if (random.NextDouble() < 0.7)
             {
                 return;
             }

--- a/StardewArchipelago/GameModifications/Modded/JunimoShopGenerator.cs
+++ b/StardewArchipelago/GameModifications/Modded/JunimoShopGenerator.cs
@@ -1,0 +1,369 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.Linq;
+using System.Xml.Schema;
+using Microsoft.Xna.Framework;
+using StardewArchipelago.Constants;
+using StardewArchipelago.Stardew;
+using StardewValley;
+using StardewValley.Locations;
+
+namespace StardewArchipelago.GameModifications.Modded
+{
+    public class JunimoShopGenerator
+    {
+        private ShopStockGenerator _shopStockGenerator;
+        private StardewItemManager _stardewItemManager;
+        private PersistentStock BluePersistentStock { get; }
+        private PersistentStock GreyPersistentStock { get; }
+        private PersistentStock YellowPersistentStock { get; }
+        private PersistentStock RedPersistentStock { get; }
+        private static Dictionary<string, JunimoVendor> JunimoVendors { get; set; }
+        private Dictionary<int, int> BlueItems { get; set; }
+        private static readonly List<string> BlueColors = new()
+        {
+            "color_blue", "color_aquamarine", "color_dark_blue", "color_cyan", "color_light_cyan"
+        };
+        private Dictionary<int, int> GreyItems { get; set; }
+        private static readonly List<string> GreyColors = new()
+        {
+            "color_gray", "color_black", "color_poppyseed", "color_dark_gray"
+        };
+        private Dictionary<int, int> RedItems { get; set; }
+        private static readonly List<string> RedColors = new()
+        {
+            "color_red", "color_pink", "color_dark_pink"
+        };
+        private Dictionary<int, int> YellowItems { get; set; }
+        private static readonly List<string> YellowColors = new()
+        {
+            "color_yellow", "color_gold", "color_sand"
+        };
+        private static readonly string[] spring = new string[]{"spring"};
+        private static readonly string[] summer = new string[]{"summer"};
+        private static readonly string[] fall = new string[]{"fall"};
+
+        private class JunimoVendor
+        {
+            public PersistentStock JunimoPersistentStock {get; private set;}
+            public Dictionary<int, int> ColorItems {get; private set;}
+
+            public JunimoVendor(PersistentStock junimoPersistentStock, Dictionary<int, int> colorItems)
+            {
+                JunimoPersistentStock = junimoPersistentStock;
+                ColorItems = colorItems;
+            }
+        }
+
+        public JunimoShopGenerator(ShopStockGenerator shopStockGenerator, StardewItemManager stardewItemManager)
+        {
+            _shopStockGenerator = shopStockGenerator;
+            _stardewItemManager = stardewItemManager;
+            RedPersistentStock = new PersistentStock();
+            GreyPersistentStock = new PersistentStock();
+            BluePersistentStock = new PersistentStock();
+            YellowPersistentStock = new PersistentStock();
+            GenerateColoredItems();
+            var blueVendor = new JunimoVendor(BluePersistentStock, BlueItems);
+            var yellowVendor = new JunimoVendor(YellowPersistentStock, YellowItems);
+            var greyVendor = new JunimoVendor(GreyPersistentStock, GreyItems);
+            var redVendor = new JunimoVendor(RedPersistentStock, RedItems);
+            JunimoVendors = new Dictionary<string, JunimoVendor>(){
+                {"Blue", blueVendor}, {"Yellow", yellowVendor}, {"Grey", greyVendor}, {"Red", redVendor}
+            };
+        }
+
+        public void GenerateColoredItems()
+        {
+            BlueItems = new Dictionary<int, int>();
+            YellowItems = new Dictionary<int, int>();
+            GreyItems = new Dictionary<int, int>();
+            RedItems = new Dictionary<int, int>();
+            var objectContextTags = Game1.content.Load<Dictionary<string, string>>("Data\\ObjectContextTags");
+
+            foreach (var contextItem in objectContextTags)
+            {
+                var itemContext = contextItem.Value;
+                if (!_stardewItemManager.ItemExists(contextItem.Key))
+                    continue;
+                var item = _stardewItemManager.GetItemByName(contextItem.Key);
+                if (item.SellPrice == 1)
+                    continue;
+                if (IsColor(itemContext, "blue") && !itemContext.Contains("fish") && !itemContext.Contains("marine"))
+                {
+                    
+                    BlueItems[item.Id] = item.SellPrice;
+                    continue;
+                }
+                if (IsColor(itemContext, "yellow"))
+                {
+                    YellowItems[item.Id] = item.SellPrice;
+                    continue;
+                }
+                if (IsColor(itemContext, "grey"))
+                {
+                    GreyItems[item.Id] = item.SellPrice;
+                }
+                if (IsColor(itemContext, "red"))
+                {
+                    RedItems[item.Id] = item.SellPrice;
+                }
+            }
+        }
+
+        private static bool IsColor(string itemContext, string color)
+        {
+            if (color == "blue")
+            {
+                return BlueColors.Any(x => itemContext.Contains(x));
+            }
+            if (color == "yellow")
+            {
+                return YellowColors.Any(x => itemContext.Contains(x));
+            }
+            if (color == "red")
+            {
+                return RedColors.Any(x => itemContext.Contains(x));
+            }
+            if (color == "grey")
+            {
+                return GreyColors.Any(x => itemContext.Contains(x));
+            }
+            return false;
+        }
+
+        public Dictionary<ISalable, int[]> GetJunimoShopStock(string color)
+        {
+            var stockAlreadyExists = JunimoVendors[color].JunimoPersistentStock.TryGetStockForToday(out var stock);
+            if (!stockAlreadyExists)
+            {
+                stock = GenerateJunimoStock(color);
+                JunimoVendors[color].JunimoPersistentStock.SetStockForToday(stock);
+            }
+
+            return stock;
+        }
+
+        private Dictionary<ISalable, int[]> GenerateJunimoStock(string color)
+        {
+            var stock = new Dictionary<ISalable, int[]>();
+            if (color == "Blue")
+            {
+                stock = GenerateBlueJunimoStock(stock);
+            }
+            if (color == "Red")
+            {
+                stock = GenerateMuseumItemsForJunimoStock("Red", stock);
+            }
+            if (color == "Grey")
+            {
+                stock = GenerateMuseumItemsForJunimoStock("Grey", stock);
+            }
+            if (color == "Yellow")
+            {
+                AddSeedsToYellowStock(stock);
+            }
+            return stock;
+        }
+
+        private static void AddToJunimoStock(
+            Dictionary<ISalable, int[]> stock,
+            int itemId,
+            string color,
+            string[] itemSeason = null)
+        {
+            var item = new StardewValley.Object(Vector2.Zero, itemId, 1);
+
+            if (itemSeason != null)
+            {
+                if (!itemSeason.Contains(Game1.currentSeason))
+                {
+                    return;
+                }
+            }
+
+            var random = new Random((int)Game1.stats.DaysPlayed + (int)Game1.uniqueIDForThisGame / 2 + itemId);
+            if (random.NextDouble() < 0.4)
+            {
+                return;
+            }
+            var itemToTrade = JunimoVendors[color].ColorItems.ElementAt(random.Next(JunimoVendors[color].ColorItems.Count));
+            var itemToTradeTotal = ExchangeRate(item, itemToTrade.Value);
+
+            if (Game1.player.hasCompletedCommunityCenter())
+            {
+                itemToTradeTotal[1] = Math.Min(1, 4* itemToTradeTotal[1] / 5);
+            }
+            item.Stack = itemToTradeTotal[0];
+            
+            stock.Add(item, new int[4]
+            {
+                0,
+                int.MaxValue,
+                itemToTrade.Key,
+                itemToTradeTotal[1],
+            });
+        }
+
+        // Lets just say they no currency good cuz Junimo
+        private static int[] ExchangeRate(Item soldItem, int wantedItem)
+        {
+            if (soldItem.salePrice() > wantedItem && soldItem.salePrice() % wantedItem == 0)
+                return new int[2]{1, soldItem.salePrice() / wantedItem};
+            if (soldItem.salePrice() <= wantedItem &&  wantedItem % soldItem.salePrice() == 0)
+                return new int[2]{wantedItem / soldItem.salePrice(), 1};
+            var gcd = Gcd(soldItem.salePrice(), wantedItem);
+            var lcm = soldItem.salePrice() * wantedItem / gcd;
+            var requestCount = lcm/soldItem.salePrice();
+            var offerCount = lcm/wantedItem;
+            var lowestTrade = 5; // This is for us to change if we want to move this value around easily in testing
+            if (Math.Min(requestCount, offerCount) > lowestTrade)
+            {
+                var closestTen = (int) Math.Pow(lowestTrade, (int) ( Math.Log10(Math.Min(requestCount, offerCount)) / Math.Log10(lowestTrade) ) );
+                requestCount /= closestTen;
+                offerCount /= closestTen;
+                requestCount /= Gcd(requestCount, offerCount); // Due to the rounding we may find the two aren't relatively prime anymore
+                offerCount /= Gcd(requestCount, offerCount);
+            }
+            
+            return new int[2]{requestCount, offerCount};
+        }
+
+        private static Dictionary<ISalable, int[]> GenerateBlueJunimoStock(Dictionary<ISalable, int[]> stock)
+        {
+            var fishData = Game1.content.Load<Dictionary<int, string>>("Data\\Fish");
+            foreach (var fish in Game1.player.fishCaught.Keys)
+            {
+                string[] fishSeasons = null;
+                if (!fishData.ContainsKey(fish))
+                {
+                    continue; // Some things you fish up aren't fish; ignore em
+                }
+                if (fish == 153 || fish == 157 || fish == 152) // We algae haters keep scrollin
+                    continue;
+                if (fishData[fish].Split("/")[1] != "trap")
+                {
+                    fishSeasons = fishData[fish].Split("/")[6].Split(" ");
+                }
+                AddToJunimoStock(stock, fish, "Blue", fishSeasons);
+            }
+            return stock;
+        }
+
+        private static Dictionary<ISalable, int[]> GenerateMuseumItemsForJunimoStock(string color, Dictionary<ISalable, int[]> stock)
+        {
+            var type = "";
+            if (color == "Grey")
+            {
+                type = "Mineral";
+            }
+            else
+            {
+                type = "Arch";
+            }
+            var libraryMuseum = Game1.getLocationFromName("ArchaeologyHouse") as  LibraryMuseum;
+            var museumItems = new HashSet<int>(libraryMuseum.museumPieces.Values);
+            var objectInformation = Game1.content.Load<Dictionary<int, string>>("Data\\ObjectInformation");
+            foreach (var museumitemId in museumItems)
+            {
+                var itemType = objectInformation[museumitemId].Split("/")[3];
+                if (!itemType.Contains(type))
+                {
+                    continue;
+                }
+                AddToJunimoStock(stock, museumitemId, color);
+            }
+            return stock;
+        }
+
+        private static int Gcd(int val1, int val2)
+        {
+            var a = Math.Max(val1, val2);
+            var b = Math.Min(val1, val2);
+            var r = a % b;
+            if ( r == 0)
+            {
+                if (val1 > val2)
+                {
+                    return val2;
+                }
+                else
+                {
+                    return val1;
+                }
+            }
+            while (r != 0)
+            {
+                a = b;
+                b = r;
+                if (a % b == 0)
+                    break;
+                r = a % b;
+            }
+            return r;
+        }
+
+        private static void AddSeedsToYellowStock(Dictionary<ISalable, int[]> stock)
+        {
+            AddSpringSeedsToYellowStock(stock);
+            AddSummerSeedsToYellowStock(stock);
+            AddFallSeedsToYellowStock(stock);
+        }
+
+        private static void AddSpringSeedsToYellowStock(Dictionary<ISalable, int[]> stock)
+        {
+            AddToJunimoStock(stock, ShopItemIds.PARSNIP_SEEDS, "Yellow", spring);
+            AddToJunimoStock(stock, ShopItemIds.BEAN_STARTER, "Yellow", spring);
+            AddToJunimoStock(stock, ShopItemIds.CAULIFLOWER_SEEDS, "Yellow", spring);
+            AddToJunimoStock(stock, ShopItemIds.POTATO_SEEDS, "Yellow", spring);
+            AddToJunimoStock(stock, ShopItemIds.TULIP_BULB, "Yellow", spring);
+            AddToJunimoStock(stock, ShopItemIds.KALE_SEEDS, "Yellow", spring);
+            AddToJunimoStock(stock, ShopItemIds.JAZZ_SEEDS, "Yellow", spring);
+            AddToJunimoStock(stock, ShopItemIds.GARLIC_SEEDS, "Yellow", spring);
+            AddToJunimoStock(stock, ShopItemIds.RICE_SHOOT, "Yellow", spring);
+        }
+
+        private static void AddSummerSeedsToYellowStock(Dictionary<ISalable, int[]> stock)
+        {
+            AddToJunimoStock(stock, ShopItemIds.MELON_SEEDS, "Yellow", summer);
+            AddToJunimoStock(stock, ShopItemIds.TOMATO_SEEDS, "Yellow", summer);
+            AddToJunimoStock(stock, ShopItemIds.BLUEBERRY_SEEDS, "Yellow", summer);
+            AddToJunimoStock(stock, ShopItemIds.PEPPER_SEEDS, "Yellow", summer);
+            AddToJunimoStock(stock, ShopItemIds.WHEAT_SEEDS, "Yellow", summer);
+            AddToJunimoStock(stock, ShopItemIds.RADISH_SEEDS, "Yellow", summer);
+            AddToJunimoStock(stock, ShopItemIds.POPPY_SEEDS, "Yellow", summer);
+            AddToJunimoStock(stock, ShopItemIds.SPANGLE_SEEDS, "Yellow", summer);
+            AddToJunimoStock(stock, ShopItemIds.HOPS_STARTER, "Yellow", summer);
+            AddToJunimoStock(stock, ShopItemIds.CORN_SEEDS, "Yellow", summer);
+            AddToJunimoStock(stock, ShopItemIds.SUNFLOWER_SEEDS, "Yellow", summer);
+            AddToJunimoStock(stock, ShopItemIds.RED_CABBAGE_SEEDS, "Yellow", summer);
+        }
+
+        private static void AddFallSeedsToYellowStock(Dictionary<ISalable, int[]> stock)
+        {
+            AddToJunimoStock(stock, ShopItemIds.PUMPKIN_SEEDS, "Yellow", fall);
+            AddToJunimoStock(stock, ShopItemIds.CORN_SEEDS, "Yellow", fall);
+            AddToJunimoStock(stock, ShopItemIds.EGGPLANT_SEEDS, "Yellow", fall);
+            AddToJunimoStock(stock, ShopItemIds.BOK_CHOY_SEEDS, "Yellow", fall);
+            AddToJunimoStock(stock, ShopItemIds.YAM_SEEDS, "Yellow", fall);
+            AddToJunimoStock(stock, ShopItemIds.CRANBERRY_SEEDS, "Yellow", fall);
+            AddToJunimoStock(stock, ShopItemIds.WHEAT_SEEDS, "Yellow", fall);
+            AddToJunimoStock(stock, ShopItemIds.SUNFLOWER_SEEDS, "Yellow", fall);
+            AddToJunimoStock(stock, ShopItemIds.FAIRY_SEEDS, "Yellow", fall);
+            AddToJunimoStock(stock, ShopItemIds.AMARANTH_SEEDS, "Yellow", fall);
+            AddToJunimoStock(stock, ShopItemIds.GRAPE_STARTER, "Yellow", fall);
+            AddToJunimoStock(stock, ShopItemIds.ARTICHOKE_SEEDS, "Yellow", fall);
+        }
+                private static void AddSaplingsToShop(Dictionary<ISalable, int[]> stock)
+        {
+            AddToJunimoStock(stock, ShopItemIds.CHERRY_SAPLING, "Yellow");
+            AddToJunimoStock(stock, ShopItemIds.APRICOT_SAPLING, "Yellow");
+            AddToJunimoStock(stock, ShopItemIds.ORANGE_SAPLING, "Yellow");
+            AddToJunimoStock(stock, ShopItemIds.PEACH_SAPLING, "Yellow");
+            AddToJunimoStock(stock, ShopItemIds.POMEGRANATE_SAPLING, "Yellow");
+            AddToJunimoStock(stock, ShopItemIds.APPLE_SAPLING, "Yellow");
+        }
+
+    }
+}

--- a/StardewArchipelago/GameModifications/Modded/JunimoShopGenerator.cs
+++ b/StardewArchipelago/GameModifications/Modded/JunimoShopGenerator.cs
@@ -117,7 +117,7 @@ namespace StardewArchipelago.GameModifications.Modded
                 var type = objectInformation[item.Id].Split("/")[3];
                 if (item.SellPrice <= 1)
                     continue;
-                if ((item.Name.Contains("Berry") || item.Name.Contains("berry")) && !item.Name.Contains("Joja") && itemContext.Contains("seeds"))
+                if ((item.Name.Contains("Berry") || item.Name.Contains("berry")) && !item.Name.Contains("Joja") && !itemContext.Contains("cooking") && !itemContext.Contains("Seeds"))
                 {
                     BerryItems[item] = item.SellPrice;
                 }

--- a/StardewArchipelago/GameModifications/Modded/JunimoShopGenerator.cs
+++ b/StardewArchipelago/GameModifications/Modded/JunimoShopGenerator.cs
@@ -84,6 +84,7 @@ namespace StardewArchipelago.GameModifications.Modded
             GreyItems = new Dictionary<int, int>();
             RedItems = new Dictionary<int, int>();
             var objectContextTags = Game1.content.Load<Dictionary<string, string>>("Data\\ObjectContextTags");
+            var objectInformation = Game1.content.Load<Dictionary<int, string>>("Data\\ObjectInformation");
 
             foreach (var contextItem in objectContextTags)
             {
@@ -104,11 +105,11 @@ namespace StardewArchipelago.GameModifications.Modded
                     YellowItems[item.Id] = item.SellPrice;
                     continue;
                 }
-                if (IsColor(itemContext, "grey"))
+                if (IsColor(itemContext, "grey") && !objectInformation[item.Id].Split("/")[3].Contains("Minerals"))
                 {
                     GreyItems[item.Id] = item.SellPrice;
                 }
-                if (IsColor(itemContext, "red"))
+                if (IsColor(itemContext, "red") && !objectInformation[item.Id].Split("/")[3].Contains("Arch"))
                 {
                     RedItems[item.Id] = item.SellPrice;
                 }
@@ -268,27 +269,26 @@ namespace StardewArchipelago.GameModifications.Modded
 
         private Dictionary<ISalable, int[]> GenerateMuseumItemsForJunimoStock(string color, Dictionary<ISalable, int[]> stock)
         {
-            var type = "";
-            if (color == "Grey")
+            var isGrey = color == "Grey";
+            var artifactsFound = Game1.player.archaeologyFound.Keys;
+            var mineralsFound = Game1.player.mineralsFound.Keys;
+            if (isGrey)
             {
-                type = "Mineral";
+                foreach (var museumitemId in mineralsFound)
+                {
+                    AddToJunimoStock(stock, museumitemId, color, false);
+                }
             }
             else
             {
-                type = "Arch";
-            }
-            var libraryMuseum = Game1.getLocationFromName("ArchaeologyHouse") as  LibraryMuseum;
-            var museumItems = new HashSet<int>(libraryMuseum.museumPieces.Values);
-            var objectInformation = Game1.content.Load<Dictionary<int, string>>("Data\\ObjectInformation");
-            foreach (var museumitemId in museumItems)
-            {
-                var itemType = objectInformation[museumitemId].Split("/")[3];
-                if (!itemType.Contains(type))
+                foreach (var museumitemId in artifactsFound)
                 {
-                    continue;
+                    if (museumitemId == 102) //No lost books smh get out
+                        continue;
+                    AddToJunimoStock(stock, museumitemId, color, false);
                 }
-                AddToJunimoStock(stock, museumitemId, color, false);
             }
+
             return stock;
         }
 

--- a/StardewArchipelago/GameModifications/Modded/JunimoShopGenerator.cs
+++ b/StardewArchipelago/GameModifications/Modded/JunimoShopGenerator.cs
@@ -361,7 +361,7 @@ namespace StardewArchipelago.GameModifications.Modded
                 return new int[2]{1, soldItem / wantedItem};
             if (soldItem <= wantedItem &&  wantedItem % soldItem == 0)
                 return new int[2]{wantedItem / soldItem, 1};
-            var gcd = Gcd(soldItem, wantedItem);
+            var gcd = GreatestCommonDivisor(soldItem, wantedItem);
             var lcm = soldItem * wantedItem / gcd;
             var requestCount = lcm/soldItem;
             var offerCount = lcm/wantedItem;
@@ -380,8 +380,8 @@ namespace StardewArchipelago.GameModifications.Modded
                 var closestTen = (int) Math.Pow(lowestTrade, (int) ( Math.Log10(Math.Min(requestCount, offerCount)) / Math.Log10(lowestTrade) ) );
                 requestCount /= closestTen;
                 offerCount /= closestTen;
-                requestCount /= Gcd(requestCount, offerCount); // Due to the rounding we may find the two aren't relatively prime anymore
-                offerCount /= Gcd(requestCount, offerCount);
+                requestCount /= GreatestCommonDivisor(requestCount, offerCount); // Due to the rounding we may find the two aren't relatively prime anymore
+                offerCount /= GreatestCommonDivisor(requestCount, offerCount);
             }
             
             return new int[2]{requestCount, offerCount};
@@ -474,31 +474,28 @@ namespace StardewArchipelago.GameModifications.Modded
             AddToJunimoStock(stock, vileAncientFruitSeeds, "Yellow", true);
         }
 
-        private static int Gcd(int val1, int val2) //Seemingly no basic method outside of BigInteger?
+        private static int GreatestCommonDivisor(int firstValue, int secondValue) //Seemingly no basic method outside of BigInteger?
         {
-            var a = Math.Max(val1, val2);
-            var b = Math.Min(val1, val2);
-            var r = a % b;
-            if ( r == 0)
+            var largestValue = Math.Max(firstValue, secondValue);
+            var lowestValue = Math.Min(firstValue, secondValue);
+            var remainder = largestValue % lowestValue;
+            if ( remainder == 0)
             {
-                if (val1 > val2)
+                if (firstValue > secondValue)
                 {
-                    return val2;
+                    return secondValue;
                 }
-                else
-                {
-                    return val1;
-                }
+                return firstValue;
             }
-            while (r != 0)
+            while (remainder != 0)
             {
-                a = b;
-                b = r;
-                if (a % b == 0)
+                largestValue = lowestValue;
+                lowestValue = remainder;
+                if (largestValue % lowestValue == 0)
                     break;
-                r = a % b;
+                remainder = largestValue % lowestValue;
             }
-            return r;
+            return remainder;
         }
     }
 }

--- a/StardewArchipelago/GameModifications/Modded/ModRandomizedLogicPatcher.cs
+++ b/StardewArchipelago/GameModifications/Modded/ModRandomizedLogicPatcher.cs
@@ -64,6 +64,11 @@ namespace StardewArchipelago.GameModifications.Modded
                 original: AccessTools.Method(typeof(GameLocation), nameof(GameLocation.answerDialogueAction)),
                 prefix: new HarmonyMethod(typeof(JunimoShopInjections), nameof(JunimoShopInjections.AnswerDialogueAction_Junimoshop_Prefix))
             );
+
+            _harmony.Patch(
+                original: AccessTools.Method(typeof(Farmer), nameof(Farmer.resetFriendshipsForNewDay)),
+                postfix: new HarmonyMethod(typeof(JunimoShopInjections), nameof(JunimoShopInjections.ResetFriendshipsForNewDay_KissForeheads_Postfix))
+            );
         }
     }
 }

--- a/StardewArchipelago/GameModifications/Modded/ModRandomizedLogicPatcher.cs
+++ b/StardewArchipelago/GameModifications/Modded/ModRandomizedLogicPatcher.cs
@@ -1,0 +1,69 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using HarmonyLib;
+using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Content;
+using Microsoft.Xna.Framework.Graphics;
+using StardewArchipelago.Archipelago;
+using StardewArchipelago.Constants;
+using StardewArchipelago.GameModifications.CodeInjections;
+using StardewArchipelago.GameModifications.CodeInjections.Modded;
+using StardewArchipelago.GameModifications.EntranceRandomizer;
+using StardewArchipelago.GameModifications.Modded;
+using StardewArchipelago.GameModifications.Seasons;
+using StardewArchipelago.GameModifications.Tooltips;
+using StardewArchipelago.Locations;
+using StardewArchipelago.Locations.CodeInjections.Vanilla.Relationship;
+using StardewArchipelago.Stardew;
+using StardewArchipelago.Stardew.NameMapping;
+using StardewModdingAPI;
+using StardewValley;
+using StardewValley.Buildings;
+using StardewValley.Events;
+using StardewValley.Locations;
+using StardewValley.Menus;
+using StardewValley.Network;
+using StardewValley.Objects;
+using Object = StardewValley.Object;
+
+namespace StardewArchipelago.GameModifications.Modded
+{
+    public class ModRandomizedLogicPatcher
+    {
+        private readonly Harmony _harmony;
+        private readonly ArchipelagoClient _archipelago;
+        private readonly StardewItemManager _stardewItemManager;
+
+        public ModRandomizedLogicPatcher(IMonitor monitor, IModHelper modHelper, Harmony harmony, ArchipelagoClient archipelago, ShopStockGenerator shopStockGenerator, StardewItemManager stardewItemManager, JunimoShopGenerator junimoShopGenerator)
+        {
+            _harmony = harmony;
+            _archipelago = archipelago;
+            JunimoShopInjections.Initialize(monitor, modHelper, archipelago, shopStockGenerator, stardewItemManager, junimoShopGenerator);
+
+        }
+
+        public void PatchAllModGameLogic()
+        {
+            PatchJunimoShops();
+        }
+
+        private void PatchJunimoShops()
+        {
+            if (!_archipelago.SlotData.Mods.HasMod(ModNames.SVE))
+            {
+                return;
+            }
+
+            _harmony.Patch(
+                original: AccessTools.Method(typeof(ShopMenu), nameof(ShopMenu.update)),
+                prefix: new HarmonyMethod(typeof(JunimoShopInjections), nameof(JunimoShopInjections.Update_JunimoWoodsAPShop_Prefix))
+            );
+
+            _harmony.Patch(
+                original: AccessTools.Method(typeof(GameLocation), nameof(GameLocation.answerDialogueAction)),
+                prefix: new HarmonyMethod(typeof(JunimoShopInjections), nameof(JunimoShopInjections.AnswerDialogueAction_Junimoshop_Prefix))
+            );
+        }
+    }
+}

--- a/StardewArchipelago/GameModifications/Modded/ModRandomizedLogicPatcher.cs
+++ b/StardewArchipelago/GameModifications/Modded/ModRandomizedLogicPatcher.cs
@@ -1,31 +1,12 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
+
 using HarmonyLib;
-using Microsoft.Xna.Framework;
-using Microsoft.Xna.Framework.Content;
-using Microsoft.Xna.Framework.Graphics;
 using StardewArchipelago.Archipelago;
 using StardewArchipelago.Constants;
-using StardewArchipelago.GameModifications.CodeInjections;
 using StardewArchipelago.GameModifications.CodeInjections.Modded;
-using StardewArchipelago.GameModifications.EntranceRandomizer;
-using StardewArchipelago.GameModifications.Modded;
-using StardewArchipelago.GameModifications.Seasons;
-using StardewArchipelago.GameModifications.Tooltips;
-using StardewArchipelago.Locations;
-using StardewArchipelago.Locations.CodeInjections.Vanilla.Relationship;
 using StardewArchipelago.Stardew;
-using StardewArchipelago.Stardew.NameMapping;
 using StardewModdingAPI;
 using StardewValley;
-using StardewValley.Buildings;
-using StardewValley.Events;
-using StardewValley.Locations;
 using StardewValley.Menus;
-using StardewValley.Network;
-using StardewValley.Objects;
-using Object = StardewValley.Object;
 
 namespace StardewArchipelago.GameModifications.Modded
 {
@@ -39,7 +20,8 @@ namespace StardewArchipelago.GameModifications.Modded
         {
             _harmony = harmony;
             _archipelago = archipelago;
-            JunimoShopInjections.Initialize(monitor, modHelper, archipelago, shopStockGenerator, stardewItemManager, junimoShopGenerator);
+            _stardewItemManager = stardewItemManager;
+            JunimoShopInjections.Initialize(monitor, modHelper, archipelago, shopStockGenerator, _stardewItemManager, junimoShopGenerator);
 
         }
 

--- a/StardewArchipelago/GameModifications/RandomizedLogicPatcher.cs
+++ b/StardewArchipelago/GameModifications/RandomizedLogicPatcher.cs
@@ -10,6 +10,7 @@ using StardewArchipelago.Constants;
 using StardewArchipelago.GameModifications.CodeInjections;
 using StardewArchipelago.GameModifications.CodeInjections.Modded;
 using StardewArchipelago.GameModifications.EntranceRandomizer;
+using StardewArchipelago.GameModifications.Modded;
 using StardewArchipelago.GameModifications.Seasons;
 using StardewArchipelago.GameModifications.Tooltips;
 using StardewArchipelago.Locations;
@@ -36,7 +37,7 @@ namespace StardewArchipelago.GameModifications
         private readonly StartingResources _startingResources;
         private readonly RecipeDataRemover _recipeDataRemover;
 
-        public RandomizedLogicPatcher(IMonitor monitor, IModHelper modHelper, Harmony harmony, ArchipelagoClient archipelago, LocationChecker locationChecker, StardewItemManager stardewItemManager, EntranceManager entranceManager, ShopStockGenerator shopStockGenerator, NameSimplifier nameSimplifier, Friends friends)
+        public RandomizedLogicPatcher(IMonitor monitor, IModHelper modHelper, Harmony harmony, ArchipelagoClient archipelago, LocationChecker locationChecker, StardewItemManager stardewItemManager, EntranceManager entranceManager, ShopStockGenerator shopStockGenerator, NameSimplifier nameSimplifier, JunimoShopGenerator junimoShopGenerator, Friends friends)
         {
             _harmony = harmony;
             _archipelago = archipelago;
@@ -68,7 +69,7 @@ namespace StardewArchipelago.GameModifications
             ItemTooltipInjections.Initialize(monitor, modHelper, archipelago, locationChecker, nameSimplifier);
             BillboardInjections.Initialize(monitor, modHelper, archipelago, locationChecker, friends);
 
-            JunimoShopInjections.Initialize(monitor, modHelper, archipelago, shopStockGenerator, _stardewItemManager);
+            JunimoShopInjections.Initialize(monitor, modHelper, archipelago, shopStockGenerator, _stardewItemManager, junimoShopGenerator);
 
             DebugPatchInjections.Initialize(monitor, archipelago);
         }

--- a/StardewArchipelago/GameModifications/RandomizedLogicPatcher.cs
+++ b/StardewArchipelago/GameModifications/RandomizedLogicPatcher.cs
@@ -69,8 +69,6 @@ namespace StardewArchipelago.GameModifications
             ItemTooltipInjections.Initialize(monitor, modHelper, archipelago, locationChecker, nameSimplifier);
             BillboardInjections.Initialize(monitor, modHelper, archipelago, locationChecker, friends);
 
-            JunimoShopInjections.Initialize(monitor, modHelper, archipelago, shopStockGenerator, _stardewItemManager, junimoShopGenerator);
-
             DebugPatchInjections.Initialize(monitor, archipelago);
         }
 
@@ -104,8 +102,6 @@ namespace StardewArchipelago.GameModifications
             PatchRecipes();
             PatchTooltips();
             _startingResources.GivePlayerStartingResources();
-
-            PatchJunimoShops();
 
             PatchDebugMethods();
         }
@@ -570,24 +566,6 @@ namespace StardewArchipelago.GameModifications
             _harmony.Patch(
                 original: AccessTools.Method(typeof(Billboard), nameof(Billboard.performHoverAction)),
                 postfix: new HarmonyMethod(typeof(BillboardInjections), nameof(BillboardInjections.PerformHoverAction_AddArchipelagoChecksToTooltips_Postfix))
-            );
-        }
-
-        private void PatchJunimoShops()
-        {
-            if (!_archipelago.SlotData.Mods.HasMod(ModNames.SVE))
-            {
-                return;
-            }
-
-            _harmony.Patch(
-                original: AccessTools.Method(typeof(ShopMenu), nameof(ShopMenu.update)),
-                prefix: new HarmonyMethod(typeof(JunimoShopInjections), nameof(JunimoShopInjections.Update_JunimoWoodsAPShop_Prefix))
-            );
-
-            _harmony.Patch(
-                original: AccessTools.Method(typeof(GameLocation), nameof(GameLocation.answerDialogueAction)),
-                prefix: new HarmonyMethod(typeof(JunimoShopInjections), nameof(JunimoShopInjections.AnswerDialogueAction_Junimoshop_Prefix))
             );
         }
 

--- a/StardewArchipelago/GameModifications/RandomizedLogicPatcher.cs
+++ b/StardewArchipelago/GameModifications/RandomizedLogicPatcher.cs
@@ -37,7 +37,7 @@ namespace StardewArchipelago.GameModifications
         private readonly StartingResources _startingResources;
         private readonly RecipeDataRemover _recipeDataRemover;
 
-        public RandomizedLogicPatcher(IMonitor monitor, IModHelper modHelper, Harmony harmony, ArchipelagoClient archipelago, LocationChecker locationChecker, StardewItemManager stardewItemManager, EntranceManager entranceManager, ShopStockGenerator shopStockGenerator, NameSimplifier nameSimplifier, JunimoShopGenerator junimoShopGenerator, Friends friends)
+        public RandomizedLogicPatcher(IMonitor monitor, IModHelper modHelper, Harmony harmony, ArchipelagoClient archipelago, LocationChecker locationChecker, StardewItemManager stardewItemManager, EntranceManager entranceManager, ShopStockGenerator shopStockGenerator, JunimoShopGenerator junimoShopGenerator, NameSimplifier nameSimplifier, Friends friends)
         {
             _harmony = harmony;
             _archipelago = archipelago;

--- a/StardewArchipelago/GameModifications/RandomizedLogicPatcher.cs
+++ b/StardewArchipelago/GameModifications/RandomizedLogicPatcher.cs
@@ -584,6 +584,11 @@ namespace StardewArchipelago.GameModifications
                 original: AccessTools.Method(typeof(ShopMenu), nameof(ShopMenu.update)),
                 prefix: new HarmonyMethod(typeof(JunimoShopInjections), nameof(JunimoShopInjections.Update_JunimoWoodsAPShop_Prefix))
             );
+
+            _harmony.Patch(
+                original: AccessTools.Method(typeof(GameLocation), nameof(GameLocation.answerDialogueAction)),
+                prefix: new HarmonyMethod(typeof(JunimoShopInjections), nameof(JunimoShopInjections.AnswerDialogueAction_Junimoshop_Prefix))
+            );
         }
 
         private void PatchDebugMethods()

--- a/StardewArchipelago/GameModifications/RandomizedLogicPatcher.cs
+++ b/StardewArchipelago/GameModifications/RandomizedLogicPatcher.cs
@@ -582,7 +582,7 @@ namespace StardewArchipelago.GameModifications
 
             _harmony.Patch(
                 original: AccessTools.Method(typeof(ShopMenu), nameof(ShopMenu.update)),
-                postfix: new HarmonyMethod(typeof(JunimoShopInjections), nameof(JunimoShopInjections.Update_JunimoWoodsAPShop_Postfix))
+                prefix: new HarmonyMethod(typeof(JunimoShopInjections), nameof(JunimoShopInjections.Update_JunimoWoodsAPShop_Prefix))
             );
         }
 

--- a/StardewArchipelago/GameModifications/RandomizedLogicPatcher.cs
+++ b/StardewArchipelago/GameModifications/RandomizedLogicPatcher.cs
@@ -6,7 +6,9 @@ using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Content;
 using Microsoft.Xna.Framework.Graphics;
 using StardewArchipelago.Archipelago;
+using StardewArchipelago.Constants;
 using StardewArchipelago.GameModifications.CodeInjections;
+using StardewArchipelago.GameModifications.CodeInjections.Modded;
 using StardewArchipelago.GameModifications.EntranceRandomizer;
 using StardewArchipelago.GameModifications.Seasons;
 using StardewArchipelago.GameModifications.Tooltips;
@@ -66,6 +68,8 @@ namespace StardewArchipelago.GameModifications
             ItemTooltipInjections.Initialize(monitor, modHelper, archipelago, locationChecker, nameSimplifier);
             BillboardInjections.Initialize(monitor, modHelper, archipelago, locationChecker, friends);
 
+            JunimoShopInjections.Initialize(monitor, modHelper, archipelago, shopStockGenerator, _stardewItemManager);
+
             DebugPatchInjections.Initialize(monitor, archipelago);
         }
 
@@ -99,6 +103,8 @@ namespace StardewArchipelago.GameModifications
             PatchRecipes();
             PatchTooltips();
             _startingResources.GivePlayerStartingResources();
+
+            PatchJunimoShops();
 
             PatchDebugMethods();
         }
@@ -563,6 +569,19 @@ namespace StardewArchipelago.GameModifications
             _harmony.Patch(
                 original: AccessTools.Method(typeof(Billboard), nameof(Billboard.performHoverAction)),
                 postfix: new HarmonyMethod(typeof(BillboardInjections), nameof(BillboardInjections.PerformHoverAction_AddArchipelagoChecksToTooltips_Postfix))
+            );
+        }
+
+        private void PatchJunimoShops()
+        {
+            if (!_archipelago.SlotData.Mods.HasMod(ModNames.SVE))
+            {
+                return;
+            }
+
+            _harmony.Patch(
+                original: AccessTools.Method(typeof(ShopMenu), nameof(ShopMenu.update)),
+                postfix: new HarmonyMethod(typeof(JunimoShopInjections), nameof(JunimoShopInjections.Update_JunimoWoodsAPShop_Postfix))
             );
         }
 

--- a/StardewArchipelago/GameModifications/ShopStockGenerator.cs
+++ b/StardewArchipelago/GameModifications/ShopStockGenerator.cs
@@ -45,6 +45,11 @@ namespace StardewArchipelago.GameModifications
             return stock;
         }
 
+        public Dictionary<ISalable, int[]> GetPierreShopStockForAnyShopMenu() // Useful if new shops act like Pierre.
+        {
+            return GeneratePierreStock();
+        }
+
         private Dictionary<ISalable, int[]> GeneratePierreStock()
         {
             var stock = new Dictionary<ISalable, int[]>();

--- a/StardewArchipelago/Items/Mail/LetterActions.cs
+++ b/StardewArchipelago/Items/Mail/LetterActions.cs
@@ -40,7 +40,7 @@ namespace StardewArchipelago.Items.Mail
             _trapManager = trapManager;
             _babyBirther = babyBirther;
             _toolUpgrader = new ToolUpgrader();
-            var modLetterActions = new ModLetterActions();
+            var modLetterActions = new ModLetterActions(_stardewItemManager);
             _letterActions = new Dictionary<string, Action<string>>();
             _letterActions.Add(LetterActionsKeys.Friendship, IncreaseFriendshipWithEveryone);
             _letterActions.Add(LetterActionsKeys.Backpack, (_) => IncreaseBackpackLevel());
@@ -81,7 +81,7 @@ namespace StardewArchipelago.Items.Mail
             _letterActions.Add(LetterActionsKeys.Trap, ExecuteTrap);
             _letterActions.Add(LetterActionsKeys.LearnCookingRecipe, LearnCookingRecipe);
             _letterActions.Add(LetterActionsKeys.LearnSpecialCraftingRecipe, LearnSpecialCraftingRecipe);
-            modLetterActions.AddModLetterActions(_letterActions, _stardewItemManager);
+            modLetterActions.AddModLetterActions(_letterActions);
         }
 
         public void ExecuteLetterAction(string key, string parameter)

--- a/StardewArchipelago/Items/Mail/LetterActions.cs
+++ b/StardewArchipelago/Items/Mail/LetterActions.cs
@@ -31,7 +31,7 @@ namespace StardewArchipelago.Items.Mail
         private readonly ToolUpgrader _toolUpgrader;
         private Dictionary<string, Action<string>> _letterActions;
 
-        public LetterActions(IModHelper modHelper, Mailman mail, ArchipelagoClient archipelago, WeaponsManager weaponsManager, TrapManager trapManager, BabyBirther babyBirther)
+        public LetterActions(IModHelper modHelper, Mailman mail, ArchipelagoClient archipelago, WeaponsManager weaponsManager, TrapManager trapManager, BabyBirther babyBirther, StardewItemManager _stardewItemManager)
         {
             _modHelper = modHelper;
             _mail = mail;
@@ -81,7 +81,7 @@ namespace StardewArchipelago.Items.Mail
             _letterActions.Add(LetterActionsKeys.Trap, ExecuteTrap);
             _letterActions.Add(LetterActionsKeys.LearnCookingRecipe, LearnCookingRecipe);
             _letterActions.Add(LetterActionsKeys.LearnSpecialCraftingRecipe, LearnSpecialCraftingRecipe);
-            modLetterActions.AddModLetterActions(_letterActions);
+            modLetterActions.AddModLetterActions(_letterActions, _stardewItemManager);
         }
 
         public void ExecuteLetterAction(string key, string parameter)

--- a/StardewArchipelago/Items/Mail/ModLetterActions.cs
+++ b/StardewArchipelago/Items/Mail/ModLetterActions.cs
@@ -9,8 +9,13 @@ namespace StardewArchipelago.Items.Mail
 {
     public class ModLetterActions
     {
+        private StardewItemManager _stardewItemManager;
         
-        public void AddModLetterActions(Dictionary<string, Action<string>> letterActions, StardewItemManager _stardewItemManager)
+        public ModLetterActions(StardewItemManager stardewItemManager)
+        {
+            _stardewItemManager = stardewItemManager;
+        }
+        public void AddModLetterActions(Dictionary<string, Action<string>> letterActions)
         {
             letterActions.Add(LetterActionsKeys.DiamondWand, (_) => ReceiveDiamondWand(_stardewItemManager));
         }

--- a/StardewArchipelago/Items/Mail/ModLetterActions.cs
+++ b/StardewArchipelago/Items/Mail/ModLetterActions.cs
@@ -3,22 +3,23 @@ using System.Linq;
 using System.Collections.Generic;
 using StardewValley;
 using StardewValley.Tools;
+using StardewArchipelago.Stardew;
 
 namespace StardewArchipelago.Items.Mail
 {
     public class ModLetterActions
     {
-        public void AddModLetterActions(Dictionary<string, Action<string>> letterActions)
+        
+        public void AddModLetterActions(Dictionary<string, Action<string>> letterActions, StardewItemManager _stardewItemManager)
         {
-            letterActions.Add(LetterActionsKeys.DiamondWand, (_) => ReceiveDiamondWand());
+            letterActions.Add(LetterActionsKeys.DiamondWand, (_) => ReceiveDiamondWand(_stardewItemManager));
         }
 
-        private void ReceiveDiamondWand()
+        private void ReceiveDiamondWand(StardewItemManager _stardewItemManager)
         {
             Game1.playSound("parry");
-            var weaponData = Game1.content.Load<Dictionary<int, string>>("Data\\weapons");
-            var id = weaponData.FirstOrDefault(x => x.Value.Contains("Diamond Wand"));
-            var diamondWand = new MeleeWeapon(id.Key);
+            var diamondWandId = _stardewItemManager.GetWeaponByName("Diamond Wand").Id;
+            var diamondWand = new MeleeWeapon(diamondWandId);
             Game1.player.holdUpItemThenMessage(diamondWand);
             Game1.player.addItemByMenuIfNecessary(diamondWand);
         } 

--- a/StardewArchipelago/Locations/CodeInjections/Initializers/CodeInjectionInitializer.cs
+++ b/StardewArchipelago/Locations/CodeInjections/Initializers/CodeInjectionInitializer.cs
@@ -5,18 +5,19 @@ using StardewArchipelago.Serialization;
 using StardewModdingAPI;
 using StardewArchipelago.Stardew;
 using StardewArchipelago.Locations.CodeInjections.Vanilla.Relationship;
+using StardewArchipelago.GameModifications.Modded;
 
 namespace StardewArchipelago.Locations.CodeInjections.Initializers
 {
     public static class CodeInjectionInitializer
     {
-        public static void Initialize(IMonitor monitor, IModHelper modHelper, ArchipelagoClient archipelago, ArchipelagoStateDto state, LocationChecker locationChecker, StardewItemManager itemManager, WeaponsManager weaponsManager, ShopStockGenerator shopStockGenerator, Friends friends)
+        public static void Initialize(IMonitor monitor, IModHelper modHelper, ArchipelagoClient archipelago, ArchipelagoStateDto state, LocationChecker locationChecker, StardewItemManager itemManager, WeaponsManager weaponsManager, ShopStockGenerator shopStockGenerator, JunimoShopGenerator junimoShopGenerator, Friends friends)
         {
             var shopReplacer = new ShopReplacer(monitor, modHelper, archipelago, locationChecker);
             VanillaCodeInjectionInitializer.Initialize(monitor, modHelper, archipelago, state, locationChecker, itemManager, weaponsManager, shopReplacer, friends);
             if (archipelago.SlotData.Mods.IsModded)
             {
-                ModCodeInjectionInitializer.Initialize(monitor, modHelper, archipelago, locationChecker, shopReplacer, shopStockGenerator);
+                ModCodeInjectionInitializer.Initialize(monitor, modHelper, archipelago, locationChecker, shopReplacer, shopStockGenerator, junimoShopGenerator);
             }
         }
     }

--- a/StardewArchipelago/Locations/CodeInjections/Initializers/ModCodeInjectionInitializer.cs
+++ b/StardewArchipelago/Locations/CodeInjections/Initializers/ModCodeInjectionInitializer.cs
@@ -7,6 +7,8 @@ using StardewArchipelago.GameModifications.CodeInjections.Modded;
 using StardewArchipelago.Locations.CodeInjections.Modded;
 using StardewArchipelago.Locations.CodeInjections.Modded.SVE;
 using StardewValley;
+using StardewArchipelago.Items;
+using StardewArchipelago.GameModifications.Modded;
 
 namespace StardewArchipelago.Locations.CodeInjections.Initializers
 {
@@ -14,13 +16,13 @@ namespace StardewArchipelago.Locations.CodeInjections.Initializers
     {
         static ArchipelagoClient _archipelago;
 
-        public static void Initialize(IMonitor monitor, IModHelper modHelper, ArchipelagoClient archipelago, LocationChecker locationChecker, ShopReplacer shopReplacer, ShopStockGenerator shopStockGenerator)
+        public static void Initialize(IMonitor monitor, IModHelper modHelper, ArchipelagoClient archipelago, LocationChecker locationChecker, ShopReplacer shopReplacer, ShopStockGenerator shopStockGenerator, JunimoShopGenerator junimoShopGenerator)
         {
             _archipelago = archipelago;
-            InitializeModdedContent(monitor, modHelper, archipelago, locationChecker, shopReplacer, shopStockGenerator);
+            InitializeModdedContent(monitor, modHelper, archipelago, locationChecker, shopReplacer, shopStockGenerator, junimoShopGenerator);
         }
 
-        private static void InitializeModdedContent(IMonitor monitor, IModHelper modHelper, ArchipelagoClient archipelago, LocationChecker locationChecker, ShopReplacer shopReplacer, ShopStockGenerator shopStockGenerator)
+        private static void InitializeModdedContent(IMonitor monitor, IModHelper modHelper, ArchipelagoClient archipelago, LocationChecker locationChecker, ShopReplacer shopReplacer, ShopStockGenerator shopStockGenerator, JunimoShopGenerator junimoShopGenerator)
         {
             if (_archipelago.SlotData.Mods.HasMod(ModNames.DEEP_WOODS))
             {
@@ -49,7 +51,7 @@ namespace StardewArchipelago.Locations.CodeInjections.Initializers
             if (archipelago.SlotData.Mods.HasMod(ModNames.SVE))
             {
                 SVECutsceneInjections.Initialize(monitor, modHelper, archipelago, locationChecker);
-                SVEShopInjections.Initialize(monitor, modHelper, archipelago, locationChecker, shopReplacer, shopStockGenerator);
+                SVEShopInjections.Initialize(monitor, modHelper, archipelago, locationChecker, shopReplacer, shopStockGenerator, junimoShopGenerator);
             }
 
             if (archipelago.SlotData.Mods.HasMod(ModNames.DISTANT_LANDS)) // Only mod for now that needs it.

--- a/StardewArchipelago/Locations/CodeInjections/Modded/SVE/SVEShopInjections.cs
+++ b/StardewArchipelago/Locations/CodeInjections/Modded/SVE/SVEShopInjections.cs
@@ -188,7 +188,7 @@ namespace StardewArchipelago.Locations.CodeInjections.Modded.SVE
             {
             var random = new Random((int)Game1.stats.DaysPlayed + (int)Game1.uniqueIDForThisGame / 2 + item.Key.salePrice());
             var itemToTrade = _junimoShopGenerator.BerryItems.ElementAt(random.Next(_junimoShopGenerator.BerryItems.Count));
-            if (item.Key.DisplayName.Contains("Baked Berry Oatmeal") || item.Key.DisplayName.Contains("Flower Cookie")) // Since these are AP locations, for logic's sake only use seasonal berries
+            if ((item.Key.DisplayName.Contains("Baked Berry Oatmeal") || item.Key.DisplayName.Contains("Flower Cookie")) && _archipelago.SlotData.Chefsanity == Chefsanity.Purchases) // Since these are AP locations, for logic's sake only use seasonal berries
             {
                 var isOatmeal = item.Key.DisplayName.Contains("Baked Berry Oatmeal");
                 var berry = seasonalBerry[Game1.currentSeason];

--- a/StardewArchipelago/Locations/CodeInjections/Modded/SVE/SVEShopInjections.cs
+++ b/StardewArchipelago/Locations/CodeInjections/Modded/SVE/SVEShopInjections.cs
@@ -56,13 +56,6 @@ namespace StardewArchipelago.Locations.CodeInjections.Modded.SVE
             {"winter", new StardewValley.Object(Vector2.Zero, 414, 1)}
         };
 
-        private static readonly Dictionary<string, Item> seasonalBerry = new(){
-            {"spring", new StardewValley.Object(Vector2.Zero, 296, 1)},
-            {"summer", new StardewValley.Object(Vector2.Zero, 396, 1)},
-            {"fall", new StardewValley.Object(Vector2.Zero, 410, 1)},
-            {"winter", new StardewValley.Object(Vector2.Zero, 414, 1)}
-        };
-
         public static void Initialize(IMonitor monitor, IModHelper modHelper, ArchipelagoClient archipelago, 
         LocationChecker locationChecker, ShopReplacer shopReplacer, ShopStockGenerator shopStockGenerator, JunimoShopGenerator junimoShopGenerator)
         {

--- a/StardewArchipelago/Locations/CodeInjections/Modded/SVE/SVEShopInjections.cs
+++ b/StardewArchipelago/Locations/CodeInjections/Modded/SVE/SVEShopInjections.cs
@@ -179,13 +179,14 @@ namespace StardewArchipelago.Locations.CodeInjections.Modded.SVE
         {
             var stock = shopMenu.itemPriceAndStock;
             var hasKnowledge = _archipelago.HasReceivedItem(BEAR_KNOWLEDGE);
-            var berryItems = _junimoShopGenerator.BerryItems.Keys.ToList();
+            var berryItems = _junimoShopGenerator.BerryItems.Keys.ToArray();
+            var random = new Random((int)Game1.stats.DaysPlayed + (int)Game1.uniqueIDForThisGame / 2);
+
             foreach (var item in stock)
             {
-                var random = new Random((int)Game1.stats.DaysPlayed + (int)Game1.uniqueIDForThisGame / 2 + item.Key.salePrice());
-                var randomBerryItem = berryItems[random.Next(berryItems.Count)];
+                var randomBerryItem = berryItems[random.Next(berryItems.Length)];
                 var randomBerryValue = _junimoShopGenerator.BerryItems[randomBerryItem];
-                if ((item.Key.Name.Contains("Baked Berry Oatmeal") || item.Key.Name.Contains("Flower Cookie")) && _archipelago.SlotData.Chefsanity == Chefsanity.Purchases) // Since these are AP locations, for logic's sake only use seasonal berries
+                if (_archipelago.SlotData.Chefsanity.HasFlag(Chefsanity.Purchases) && (item.Key.Name.Contains("Baked Berry Oatmeal") || item.Key.Name.Contains("Flower Cookie"))) // Since these are AP locations, for logic's sake only use seasonal berries
                 {
                     var isOatmeal = item.Key.Name.Contains("Baked Berry Oatmeal");
                     var logicalBerry = seasonalBerry[Game1.currentSeason];

--- a/StardewArchipelago/Locations/CodeInjections/Modded/SVE/SVEShopInjections.cs
+++ b/StardewArchipelago/Locations/CodeInjections/Modded/SVE/SVEShopInjections.cs
@@ -179,33 +179,33 @@ namespace StardewArchipelago.Locations.CodeInjections.Modded.SVE
             var hasKnowledge = _archipelago.HasReceivedItem(BEAR_KNOWLEDGE);
             foreach (var item in stock)
             {
-            var random = new Random((int)Game1.stats.DaysPlayed + (int)Game1.uniqueIDForThisGame / 2 + item.Key.salePrice());
-            var itemToTrade = _junimoShopGenerator.BerryItems.ElementAt(random.Next(_junimoShopGenerator.BerryItems.Count));
-            if ((item.Key.DisplayName.Contains("Baked Berry Oatmeal") || item.Key.DisplayName.Contains("Flower Cookie")) && _archipelago.SlotData.Chefsanity == Chefsanity.Purchases) // Since these are AP locations, for logic's sake only use seasonal berries
-            {
-                var isOatmeal = item.Key.DisplayName.Contains("Baked Berry Oatmeal");
-                var berry = seasonalBerry[Game1.currentSeason];
-                var berryRate = JunimoShopGenerator.ExchangeRate(isOatmeal ? 12500 : 8750 , berry.salePrice() * (hasKnowledge ? 3 : 1));
-                stock[item.Key] = new int[4]
+                var random = new Random((int)Game1.stats.DaysPlayed + (int)Game1.uniqueIDForThisGame / 2 + item.Key.salePrice());
+                var itemToTrade = _junimoShopGenerator.BerryItems.ElementAt(random.Next(_junimoShopGenerator.BerryItems.Count));
+                if ((item.Key.DisplayName.Contains("Baked Berry Oatmeal") || item.Key.DisplayName.Contains("Flower Cookie")) && _archipelago.SlotData.Chefsanity == Chefsanity.Purchases) // Since these are AP locations, for logic's sake only use seasonal berries
                 {
+                    var isOatmeal = item.Key.DisplayName.Contains("Baked Berry Oatmeal");
+                    var berry = seasonalBerry[Game1.currentSeason];
+                    var berryRate = JunimoShopGenerator.ExchangeRate(isOatmeal ? 12500 : 8750, berry.salePrice() * (hasKnowledge ? 3 : 1));
+                    stock[item.Key] = new int[4]
+                    {
                     0,
                     int.MaxValue,
                     seasonalBerry[Game1.currentSeason].ParentSheetIndex,
                     (int) Math.Pow(berryRate[1] / berryRate[0], 0.75)
-                };
-                continue;
-            }
-            var itemToTradeTotal = JunimoShopGenerator.ExchangeRate(item.Key.salePrice(), itemToTrade.Value * (hasKnowledge ? 3 : 1));
-            
-            item.Key.Stack = itemToTradeTotal[0];
-            
-            stock[item.Key] = new int[4]
-            {
+                    };
+                    continue;
+                }
+                var itemToTradeTotal = JunimoShopGenerator.ExchangeRate(item.Key.salePrice(), itemToTrade.Value * (hasKnowledge ? 3 : 1));
+
+                item.Key.Stack = itemToTradeTotal[0];
+
+                stock[item.Key] = new int[4]
+                {
                 0,
                 int.MaxValue,
                 itemToTrade.Key.Id,
                 itemToTradeTotal[1],
-            };
+                };
             }
         }
 

--- a/StardewArchipelago/Locations/CodeInjections/Vanilla/Relationship/FriendshipInjections.cs
+++ b/StardewArchipelago/Locations/CodeInjections/Vanilla/Relationship/FriendshipInjections.cs
@@ -404,7 +404,13 @@ namespace StardewArchipelago.Locations.CodeInjections.Vanilla.Relationship
                 {
                     PerformFriendshipDecay(__instance, npcName);
                 }
-
+                if (Game1.player.hasOrWillReceiveMail("purpleJunimoKiss"))
+                foreach (var friendship in Game1.player.friendshipData.Keys)
+                    {
+                        var friend = Game1.getCharacterFromName(friendship);
+                        Game1.player.changeFriendship(100, friend);
+                }
+                Game1.player.RemoveMail("purpleJunimoKiss");
                 var date = new WorldDate(Game1.Date);
                 ++date.TotalDays;
                 __instance.updateFriendshipGifts(date);

--- a/StardewArchipelago/Locations/CodeInjections/Vanilla/Relationship/FriendshipInjections.cs
+++ b/StardewArchipelago/Locations/CodeInjections/Vanilla/Relationship/FriendshipInjections.cs
@@ -404,15 +404,6 @@ namespace StardewArchipelago.Locations.CodeInjections.Vanilla.Relationship
                 {
                     PerformFriendshipDecay(__instance, npcName);
                 }
-                if (Game1.player.mailReceived.Contains("purpleJunimoKiss"))
-                {
-                    foreach (var friendship in Game1.player.friendshipData.Keys)
-                    {
-                        var friend = Game1.getCharacterFromName(friendship);
-                        Game1.player.changeFriendship(100, friend);
-                    }
-                    Game1.player.mailReceived.Remove("purpleJunimoKiss");
-                }
                 var date = new WorldDate(Game1.Date);
                 ++date.TotalDays;
                 __instance.updateFriendshipGifts(date);

--- a/StardewArchipelago/Locations/CodeInjections/Vanilla/Relationship/FriendshipInjections.cs
+++ b/StardewArchipelago/Locations/CodeInjections/Vanilla/Relationship/FriendshipInjections.cs
@@ -404,13 +404,15 @@ namespace StardewArchipelago.Locations.CodeInjections.Vanilla.Relationship
                 {
                     PerformFriendshipDecay(__instance, npcName);
                 }
-                if (Game1.player.hasOrWillReceiveMail("purpleJunimoKiss"))
-                foreach (var friendship in Game1.player.friendshipData.Keys)
+                if (Game1.player.mailReceived.Contains("purpleJunimoKiss"))
+                {
+                    foreach (var friendship in Game1.player.friendshipData.Keys)
                     {
                         var friend = Game1.getCharacterFromName(friendship);
                         Game1.player.changeFriendship(100, friend);
+                    }
+                    Game1.player.mailReceived.Remove("purpleJunimoKiss");
                 }
-                Game1.player.RemoveMail("purpleJunimoKiss");
                 var date = new WorldDate(Game1.Date);
                 ++date.TotalDays;
                 __instance.updateFriendshipGifts(date);

--- a/StardewArchipelago/Locations/Patcher/LocationPatcher.cs
+++ b/StardewArchipelago/Locations/Patcher/LocationPatcher.cs
@@ -2,6 +2,7 @@
 using HarmonyLib;
 using StardewArchipelago.Archipelago;
 using StardewArchipelago.GameModifications;
+using StardewArchipelago.GameModifications.Modded;
 using StardewArchipelago.Locations.CodeInjections.Initializers;
 using StardewArchipelago.Locations.CodeInjections.Vanilla.MonsterSlayer;
 using StardewArchipelago.Locations.CodeInjections.Vanilla.Relationship;
@@ -15,9 +16,9 @@ namespace StardewArchipelago.Locations.Patcher
     {
         private List<ILocationPatcher> _patchers;
 
-        public LocationPatcher(IMonitor monitor, IModHelper modHelper, Harmony harmony, ArchipelagoClient archipelago, ArchipelagoStateDto state, LocationChecker locationChecker, StardewItemManager itemManager, WeaponsManager weaponsManager, ShopStockGenerator shopStockGenerator, Friends friends)
+        public LocationPatcher(IMonitor monitor, IModHelper modHelper, Harmony harmony, ArchipelagoClient archipelago, ArchipelagoStateDto state, LocationChecker locationChecker, StardewItemManager itemManager, WeaponsManager weaponsManager, ShopStockGenerator shopStockGenerator, JunimoShopGenerator junimoShopGenerator, Friends friends)
         {
-            CodeInjectionInitializer.Initialize(monitor, modHelper, archipelago, state, locationChecker, itemManager, weaponsManager, shopStockGenerator, friends);
+            CodeInjectionInitializer.Initialize(monitor, modHelper, archipelago, state, locationChecker, itemManager, weaponsManager, shopStockGenerator, junimoShopGenerator, friends);
             _patchers = new List<ILocationPatcher>();
             _patchers.Add(new VanillaLocationPatcher(monitor, modHelper, harmony, archipelago, locationChecker));
             if (archipelago.SlotData.Mods.IsModded)

--- a/StardewArchipelago/ModEntry.cs
+++ b/StardewArchipelago/ModEntry.cs
@@ -273,7 +273,7 @@ namespace StardewArchipelago
                 _itemManager = new ItemManager(Monitor, _helper, _harmony, _archipelago, _stardewItemManager, _mail, tileChooser, babyBirther, _giftHandler.Sender, State.ItemsReceived);
                 var weaponsManager = new WeaponsManager(_stardewItemManager, _archipelago.SlotData.Mods);
                 _mailPatcher = new MailPatcher(Monitor, _harmony, _archipelago, _locationChecker, State,
-                    new LetterActions(_helper, _mail, _archipelago, weaponsManager, _itemManager.TrapManager, babyBirther));
+                    new LetterActions(_helper, _mail, _archipelago, weaponsManager, _itemManager.TrapManager, babyBirther, _stardewItemManager));
                 var bundlesManager = new BundlesManager(_helper, _stardewItemManager, _archipelago.SlotData.BundlesData);
                 bundlesManager.ReplaceAllBundles();
                 _locationsPatcher = new LocationPatcher(Monitor, _helper, _harmony, _archipelago, State, _locationChecker, _stardewItemManager, weaponsManager, shopStockGenerator, junimoShopGenerator, friends);

--- a/StardewArchipelago/ModEntry.cs
+++ b/StardewArchipelago/ModEntry.cs
@@ -228,9 +228,10 @@ namespace StardewArchipelago
                 _goalManager = new GoalManager(Monitor, _helper, _harmony, _archipelago, _locationChecker);
                 _entranceManager = new EntranceManager(Monitor, _archipelago);
                 var shopStockGenerator = new ShopStockGenerator(Monitor, _helper, _archipelago, _locationChecker);
+                var junimoShopGenerator = new JunimoShopGenerator(_archipelago, shopStockGenerator, _stardewItemManager);
                 var nameSimplifier = new NameSimplifier();
                 var friends = new Friends();
-                _logicPatcher = new RandomizedLogicPatcher(Monitor, _helper, _harmony, _archipelago, _locationChecker, _stardewItemManager, _entranceManager, shopStockGenerator, nameSimplifier, friends);
+                _logicPatcher = new RandomizedLogicPatcher(Monitor, _helper, _harmony, _archipelago, _locationChecker, _stardewItemManager, _entranceManager, shopStockGenerator, junimoShopGenerator, nameSimplifier, friends);
                 _jojaDisabler = new JojaDisabler(Monitor, _helper, _harmony);
                 _seasonsRandomizer = new SeasonsRandomizer(Monitor, _helper, _archipelago, State);
                 _appearanceRandomizer = new AppearanceRandomizer(Monitor, _archipelago);
@@ -273,7 +274,7 @@ namespace StardewArchipelago
                     new LetterActions(_helper, _mail, _archipelago, weaponsManager, _itemManager.TrapManager, babyBirther));
                 var bundlesManager = new BundlesManager(_helper, _stardewItemManager, _archipelago.SlotData.BundlesData);
                 bundlesManager.ReplaceAllBundles();
-                _locationsPatcher = new LocationPatcher(Monitor, _helper, _harmony, _archipelago, State, _locationChecker, _stardewItemManager, weaponsManager, shopStockGenerator, friends);
+                _locationsPatcher = new LocationPatcher(Monitor, _helper, _harmony, _archipelago, State, _locationChecker, _stardewItemManager, weaponsManager, shopStockGenerator, junimoShopGenerator, friends);
                 _shippingBehaviors = new NightShippingBehaviors(Monitor, _archipelago, _locationChecker, nameSimplifier);
                 _chatForwarder.ListenToChatMessages();
                 _logicPatcher.PatchAllGameLogic();

--- a/StardewArchipelago/ModEntry.cs
+++ b/StardewArchipelago/ModEntry.cs
@@ -65,6 +65,7 @@ namespace StardewArchipelago
         private EntranceManager _entranceManager;
         private NightShippingBehaviors _shippingBehaviors;
 
+        private ModRandomizedLogicPatcher _modLogicPatcher;
         private CallableModData _callableModData;
         private ModifiedVillagerEventChecker _villagerEvents;
 
@@ -232,6 +233,7 @@ namespace StardewArchipelago
                 var nameSimplifier = new NameSimplifier();
                 var friends = new Friends();
                 _logicPatcher = new RandomizedLogicPatcher(Monitor, _helper, _harmony, _archipelago, _locationChecker, _stardewItemManager, _entranceManager, shopStockGenerator, junimoShopGenerator, nameSimplifier, friends);
+                _modLogicPatcher = new ModRandomizedLogicPatcher(Monitor, _helper, _harmony, _archipelago, shopStockGenerator, _stardewItemManager, junimoShopGenerator);
                 _jojaDisabler = new JojaDisabler(Monitor, _helper, _harmony);
                 _seasonsRandomizer = new SeasonsRandomizer(Monitor, _helper, _archipelago, State);
                 _appearanceRandomizer = new AppearanceRandomizer(Monitor, _archipelago);
@@ -278,6 +280,7 @@ namespace StardewArchipelago
                 _shippingBehaviors = new NightShippingBehaviors(Monitor, _archipelago, _locationChecker, nameSimplifier);
                 _chatForwarder.ListenToChatMessages();
                 _logicPatcher.PatchAllGameLogic();
+                _modLogicPatcher.PatchAllModGameLogic();
                 _mailPatcher.PatchMailBoxForApItems();
                 _entranceManager.SetEntranceRandomizerSettings(_archipelago.SlotData);
                 _locationsPatcher.ReplaceAllLocationsRewardsWithChecks();


### PR DESCRIPTION
Adds a new feature where the junimos and bear barter; not using gold as currency.

- Every junimo is handled this way
  - Red: Deals in all found artifacts by the player.  Trades in red items.
  - Grey: Deals in all found minerals by the player.  Trades in grey items.
  - Yellow: Deals in all seeds that would normally be sold by Pierre or Sandy.  Trades in yellow items.
  - Blue: Deals in all fish caught by the player.  Trades in blue items.
  - Orange: Deals in all meals cooked by the player.  Trades in orange items.
   - Purple: Offers money, dewdrops, or friendship bonuses.  Trades in purple items.  Request changes once a month.
- Bear in Forest West now accepts berries as currency.
  - If chefsanity is on, the recipes are forced to be only the basic foragables for the season the player is on.  Price is given an exponent of 0.75 (4/3 root).