### PR TITLE
Add Lucky Lunch Recipe to Luck

### DIFF
--- a/StardewArchipelago/Locations/CodeInjections/Vanilla/RecipeLevelUpInjections.cs
+++ b/StardewArchipelago/Locations/CodeInjections/Vanilla/RecipeLevelUpInjections.cs
@@ -71,15 +71,13 @@ namespace StardewArchipelago.Locations.CodeInjections.Vanilla
         }
 
         // public LevelUpMenu(string skillName, int level)
-        /*public static void SkillLevelUpMenuConstructor_SendModdedSkillRecipeChecks_Postfix(IClickableMenu __instance, string skillName, int level)
+        public static void SkillLevelUpMenuConstructor_SendModdedSkillRecipeChecks_Postfix(IClickableMenu __instance, string skillName, int level)
         {
             try
             {
-                var newCraftingRecipesField = _helper.Reflection.GetField<List<CraftingRecipe>>(__instance, "newCraftingRecipes");
-                var newCraftingRecipes = newCraftingRecipesField.GetValue();
-                var skillActualName = skillName.Split('.').Last().Replace("Skill", "");
+                var skillActualName = skillName.Split('.')[^1].Replace("Skill", "");
                 var skill = Enum.Parse<Skill>(skillActualName);
-                SendModdedSkillRecipeChecks(skill, level);
+                SendSkillRecipeChecks(skill, level);
                 return;
             }
             catch (Exception ex)
@@ -88,34 +86,6 @@ namespace StardewArchipelago.Locations.CodeInjections.Vanilla
                 return;
             }
         }
-
-        private static void SendModdedSkillRecipeChecks(Skill skill, int level)
-        {
-            SendModdedSkillCraftingRecipeChecks(skill, level);
-        }
-
-        private static void SendModdedSkillCraftingRecipeChecks(Skill skill, int level)
-        {
-            if (!_archipelago.SlotData.Craftsanity.HasFlag(Craftsanity.All) || !_craftingRecipesBySkill.ContainsKey(skill))
-            {
-                return;
-            }
-
-            var skillRecipes = _craftingRecipesBySkill[skill];
-            for (var i = 0; i <= level; i++)
-            {
-                if (!skillRecipes.ContainsKey(i))
-                {
-                    continue;
-                }
-
-                var skillRecipesAtLevel = skillRecipes[i];
-                foreach (var skillRecipe in skillRecipesAtLevel)
-                {
-                    _locationChecker.AddCheckedLocation($"{skillRecipe}{RecipePurchaseInjections.CHEFSANITY_LOCATION_SUFFIX}");
-                }
-            }
-        }*/
 
         private static readonly Dictionary<Skill, Dictionary<int, string[]>> _cookingRecipesBySkill = new()
         {
@@ -151,6 +121,12 @@ namespace StardewArchipelago.Locations.CodeInjections.Vanilla
                     { 9, new[] { "Squid Ink Ravioli" } },
                 }
             },
+            {
+                Skill.Luck, new Dictionary<int, string[]>()
+                {
+                    { 8, new[] { "Lucky Lunch" } }
+                }
+            }
         };
 
         /*private static readonly Dictionary<Skill, Dictionary<int, string[]>> _craftingRecipesBySkill = new()

--- a/StardewArchipelago/Locations/CodeInjections/Vanilla/RecipeLevelUpInjections.cs
+++ b/StardewArchipelago/Locations/CodeInjections/Vanilla/RecipeLevelUpInjections.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using StardewArchipelago.Archipelago;
 using StardewModdingAPI;
 using StardewValley.Menus;
@@ -75,8 +76,12 @@ namespace StardewArchipelago.Locations.CodeInjections.Vanilla
         {
             try
             {
-                var skillActualName = skillName.Split('.')[^1].Replace("Skill", "");
-                var skill = Enum.Parse<Skill>(skillActualName);
+                var skillActualName = skillName.Split('.').Last().Replace("Skill", "");
+                var skillCheck = Enum.TryParse<Skill>(skillActualName, out var skill);
+                if (!skillCheck)
+                {
+                    return;
+                }
                 SendSkillRecipeChecks(skill, level);
                 return;
             }

--- a/StardewArchipelago/Locations/Patcher/ModLocationPatcher.cs
+++ b/StardewArchipelago/Locations/Patcher/ModLocationPatcher.cs
@@ -82,10 +82,10 @@ namespace StardewArchipelago.Locations.Patcher
                     postfix: new HarmonyMethod(typeof(MagicModInjections), nameof(MagicModInjections.Update_ReplaceMarlonShopChecks_Postfix))
             );
             }
-            /*_harmony.Patch(
+            _harmony.Patch(
                 original: AccessTools.Constructor(_spaceCoreInterfaceType, new[] {typeof(string), typeof(int)}),
                 postfix: new HarmonyMethod(typeof(RecipeLevelUpInjections), nameof(RecipeLevelUpInjections.SkillLevelUpMenuConstructor_SendModdedSkillRecipeChecks_Postfix))
-            );*/
+            );
                 
             InjectSocializingExperienceMultiplier();
             InjectArchaeologyExperienceMultiplier();

--- a/StardewArchipelago/ModEntry.cs
+++ b/StardewArchipelago/ModEntry.cs
@@ -369,10 +369,10 @@ namespace StardewArchipelago
 
         private void DoBugsCleanup()
         {
-            if (_archipelago.SlotData.Mods.HasMod(ModNames.LUCK) && Game1.player.LuckLevel >= 8 && !_locationChecker.IsLocationChecked("Lucky Lunch Recipe"))
+            if (_archipelago.SlotData.Mods.HasMod(ModNames.LUCK) && Game1.player.LuckLevel >= 8 && !_locationChecker.IsLocationMissingAndExists("Lucky Lunch Recipe"))
             {
                 _locationChecker.AddCheckedLocation("Lucky Lunch Recipe");
-                if (!_archipelago.HasReceivedItem("Lucky Lunch Recipe"))
+                if (_archipelago.SlotData.Chefsanity.HasFlag(Chefsanity.Skills) && !_archipelago.HasReceivedItem("Lucky Lunch Recipe"))
                 {
                     Game1.player.cookingRecipes.Remove("Lucky Lunch");
                 }

--- a/StardewArchipelago/ModEntry.cs
+++ b/StardewArchipelago/ModEntry.cs
@@ -369,6 +369,14 @@ namespace StardewArchipelago
 
         private void DoBugsCleanup()
         {
+            if (_archipelago.SlotData.Mods.HasMod(ModNames.LUCK) && Game1.player.LuckLevel >= 8 && !_locationChecker.IsLocationChecked("Lucky Lunch Recipe"))
+            {
+                _locationChecker.AddCheckedLocation("Lucky Lunch Recipe");
+                if (!_archipelago.HasReceivedItem("Lucky Lunch Recipe"))
+                {
+                    Game1.player.cookingRecipes.Remove("Lucky Lunch");
+                }
+            }
             // Fix to remove dupes in Railroad Boulder
             if (!_archipelago.SlotData.Mods.HasMod(ModNames.SVE))
             {

--- a/StardewArchipelago/ModEntry.cs
+++ b/StardewArchipelago/ModEntry.cs
@@ -369,10 +369,10 @@ namespace StardewArchipelago
 
         private void DoBugsCleanup()
         {
-            if (_archipelago.SlotData.Mods.HasMod(ModNames.LUCK) && Game1.player.LuckLevel >= 8 && !_locationChecker.IsLocationMissingAndExists("Lucky Lunch Recipe"))
+            if (_archipelago.SlotData.Mods.HasMod(ModNames.LUCK) && Game1.player.LuckLevel >= 8 && _locationChecker.IsLocationMissingAndExists("Lucky Lunch Recipe"))
             {
                 _locationChecker.AddCheckedLocation("Lucky Lunch Recipe");
-                if (_archipelago.SlotData.Chefsanity.HasFlag(Chefsanity.Skills) && !_archipelago.HasReceivedItem("Lucky Lunch Recipe"))
+                if (_archipelago.SlotData.Chefsanity.HasFlag(Chefsanity.Skills) && !_archipelago.HasReceivedItem("Lucky Lunch Recipe") && Game1.player.cookingRecipes.ContainsKey("Lucky Lunch"))
                 {
                     Game1.player.cookingRecipes.Remove("Lucky Lunch");
                 }


### PR DESCRIPTION
Luck Skill has Lucky Lunch as a recipe at level 8.  There's really no reason to not include it as a recipe source, so this adds it.  It was a bug that you get the recipe at 8 normally so a patch is made to remove it from inventory and give the check if relevant.