### PR TITLE
Fix Krobus' Protection and Increment CP Mod Version

### DIFF
--- a/StardewArchipelago/Constants/ModVersions.cs
+++ b/StardewArchipelago/Constants/ModVersions.cs
@@ -44,7 +44,7 @@ namespace StardewArchipelago.Constants
         }
 
         public static readonly Dictionary<string, ContentPatcherRequirement> CPVersions = new(){
-            {ModNames.SVE, new ContentPatcherRequirement(ModNames.AP_SVE, "1.0.0")},
+            {ModNames.SVE, new ContentPatcherRequirement(ModNames.AP_SVE, "1.0.1")},
             {ModNames.ALECTO, new ContentPatcherRequirement(ModNames.AP_ALECTO, "1.0.0")},
             {ModNames.JASPER, new ContentPatcherRequirement(ModNames.AP_JASPER, "1.0.0")}
         };

--- a/StardewArchipelago/Items/Unlocks/SVEUnlockManager.cs
+++ b/StardewArchipelago/Items/Unlocks/SVEUnlockManager.cs
@@ -9,7 +9,7 @@ namespace StardewArchipelago.Items.Unlocks
     {
         public const string DIAMOND_WAND_AP_NAME = "Diamond Wand";
         public const string MARLON_BOAT_PADDLE_AP_NAME = "Marlon's Boat Paddle";
-        public const string VOID_SOUL_AP_NAME = "Void Soul";
+        public const string VOID_SOUL_AP_NAME = "Krobus' Protection";
         public const string IRIDIUM_BOMB_AP_NAME = "Iridium Bomb";
         public const string KITTYFISH_SPELL_AP_NAME = "Kittyfish Spell";
         public const string GUILD_RUNES_AP_NAME = "Nexus: Adventurer's Guild Runes";

--- a/StardewArchipelago/Locations/CodeInjections/Modded/SVE/SVECutsceneInjections.cs
+++ b/StardewArchipelago/Locations/CodeInjections/Modded/SVE/SVECutsceneInjections.cs
@@ -24,6 +24,10 @@ namespace StardewArchipelago.Locations.CodeInjections.Modded.SVE
         private const int RAILROAD_BOULDER_ID = 8050108;
         private const int IRIDIUM_BOMB_ID = 8050109;
         private const string LANCE_CHEST = "Lance's Diamond Wand";
+        private const string MONSTER_ERADICATION_AP_PREFIX = "Monster Eradication: ";
+        private static readonly List<string> voidSpirits = new(){
+            MonsterName.SHADOW_BRUTE, MonsterName.SHADOW_GUY, MonsterName.SHADOW_SHAMAN, MonsterName.SHADOW_SNIPER
+            };
         private static readonly Dictionary<int, string> sveEventSpecialOrders = new(){
             {8050108, "Clint2"},
             {2551994, "Clint3"},
@@ -118,6 +122,26 @@ namespace StardewArchipelago.Locations.CodeInjections.Modded.SVE
             {
                 _monitor.Log($"Failed in {nameof(UpdateSpecialOrders_StopDeletingSpecialOrders_Prefix)}:\n{ex}", LogLevel.Error);
                 return true; // run original logic
+            }
+        }
+        // private static void FixMonsterSlayerQuest()
+        public static void FixMonsterSlayerQuest_IncludeReleaseofGoals_Postfix()
+        {
+            try
+            {
+                foreach (var voidSpirit in voidSpirits)
+                {
+                    var locationName = $"{MONSTER_ERADICATION_AP_PREFIX}{voidSpirit}";
+                    if (_locationChecker.IsLocationMissingAndExists(locationName))
+                    {
+                        _locationChecker.AddCheckedLocation(locationName);
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                _monitor.Log($"Failed in {nameof(FixMonsterSlayerQuest_IncludeReleaseofGoals_Postfix)}:\n{ex}", LogLevel.Error);
+                return;
             }
         }
     }

--- a/StardewArchipelago/Locations/CodeInjections/Modded/SVE/SVECutsceneInjections.cs
+++ b/StardewArchipelago/Locations/CodeInjections/Modded/SVE/SVECutsceneInjections.cs
@@ -26,7 +26,9 @@ namespace StardewArchipelago.Locations.CodeInjections.Modded.SVE
         private const string LANCE_CHEST = "Lance's Diamond Wand";
         private const string MONSTER_ERADICATION_AP_PREFIX = "Monster Eradication: ";
         private static readonly List<string> voidSpirits = new(){
-            MonsterName.SHADOW_BRUTE, MonsterName.SHADOW_GUY, MonsterName.SHADOW_SHAMAN, MonsterName.SHADOW_SNIPER
+            MonsterName.SHADOW_BRUTE, MonsterName.SHADOW_SHAMAN, MonsterName.SHADOW_SNIPER, MonsterCategory.VOID_SPIRITS,
+            string.Join("30 ",MonsterCategory.VOID_SPIRITS), string.Join("60 ",MonsterCategory.VOID_SPIRITS), 
+            string.Join("90 ",MonsterCategory.VOID_SPIRITS), string.Join("120 ",MonsterCategory.VOID_SPIRITS)
             };
         private static readonly Dictionary<int, string> sveEventSpecialOrders = new(){
             {8050108, "Clint2"},

--- a/StardewArchipelago/Locations/CodeInjections/Modded/SVE/SVECutsceneInjections.cs
+++ b/StardewArchipelago/Locations/CodeInjections/Modded/SVE/SVECutsceneInjections.cs
@@ -124,6 +124,8 @@ namespace StardewArchipelago.Locations.CodeInjections.Modded.SVE
                 return true; // run original logic
             }
         }
+
+        // Original method runs on SaveLoaded, OnWarped, TimeChanged
         // private static void FixMonsterSlayerQuest()
         public static void FixMonsterSlayerQuest_IncludeReleaseofGoals_Postfix()
         {

--- a/StardewArchipelago/Locations/Patcher/ModLocationPatcher.cs
+++ b/StardewArchipelago/Locations/Patcher/ModLocationPatcher.cs
@@ -316,6 +316,13 @@ namespace StardewArchipelago.Locations.Patcher
                 original: AccessTools.Method(specialOrderAfterEventsType, "UpdateSpecialOrders"),
                 prefix: new HarmonyMethod(typeof(SVECutsceneInjections), nameof(SVECutsceneInjections.UpdateSpecialOrders_StopDeletingSpecialOrders_Prefix))
             );
+
+            var disableShadowAttacksType = AccessTools.TypeByName("DisableShadowAttacks");
+
+            _harmony.Patch(
+                original: AccessTools.Method(disableShadowAttacksType, "FixMonsterSlayerQuest"),
+                postfix: new HarmonyMethod(typeof(SVECutsceneInjections), nameof(SVECutsceneInjections.FixMonsterSlayerQuest_IncludeReleaseofGoals_Postfix))
+            );
         }
     }
 }

--- a/StardewArchipelago/ModEntry.cs
+++ b/StardewArchipelago/ModEntry.cs
@@ -413,6 +413,10 @@ namespace StardewArchipelago
                 Game1.player.craftingRecipes.Remove("Ginger Tincture");
                 _locationChecker.AddCheckedLocation("Ginger Tincture Recipe");
             }
+            if (_archipelago.HasReceivedItem("Krobus' Protection") && !Game1.player.mailReceived.Contains("GaveVoidSouls"))
+            {
+                Game1.player.mailReceived.Add("GaveVoidSouls");
+            }
         }
 
         private void OnDayEnding(object sender, DayEndingEventArgs e)

--- a/StardewArchipelago/Stardew/NameMapping/NameSimplifier.cs
+++ b/StardewArchipelago/Stardew/NameMapping/NameSimplifier.cs
@@ -37,6 +37,10 @@ namespace StardewArchipelago.Stardew.NameMapping
                 {
                     displayName = displayName.Replace("Trilobite Fossil", "Trilobite");
                 }
+                if (displayName.Contains("Rusty Sur"))
+                {
+                    displayName = displayName.Replace("Sur", "Spur");
+                }
                 name = displayName;
             }
 


### PR DESCRIPTION
- Fixes the name for Krobus' Protection.  The event will now properly play if the item is received. 
  - Bugfix implemented that gives the player the correct item if they had the item already
- If the player views the cutscene which gives them immunity, release all monster eradication goals for void spirits.
  - Note: This is done as this behavior is in-line with SVE's design.
- Increments mod version for SVE mod to 1.0.1.
- Fixes Rusty Spur item name due to typo from Archaeology dev.