### PR TITLE
Sve fixes 8

### DIFF
--- a/StardewArchipelago/Locations/CodeInjections/Modded/DeepWoodsModInjections.cs
+++ b/StardewArchipelago/Locations/CodeInjections/Modded/DeepWoodsModInjections.cs
@@ -65,8 +65,8 @@ namespace StardewArchipelago.Locations.CodeInjections.Modded
                 var hasPendantDepths = _archipelago.HasReceivedItem(PENDANT_DEPTHS_ITEM);
                 var hasPendantCommunity = _archipelago.HasReceivedItem(PENDANT_COMMUNITY_ITEM);
 
-                if (Game1.player.LuckLevel == 7
-                    && totalSkill == 40
+                if (Game1.player.LuckLevel >= 7
+                    && totalSkill >= 40
                     && hasPendantElders
                     && hasPendantDepths
                     && hasPendantCommunity)

--- a/StardewArchipelago/Locations/CodeInjections/Modded/DeepWoodsModInjections.cs
+++ b/StardewArchipelago/Locations/CodeInjections/Modded/DeepWoodsModInjections.cs
@@ -113,6 +113,11 @@ namespace StardewArchipelago.Locations.CodeInjections.Modded
                 var deepWoodsState = deepWoodsStateProperty.GetValue(null);
                 var lowestLevelReachedField = _helper.Reflection.GetField<int>(deepWoodsState, "lowestLevelReached");
                 
+                if (_archipelago.GetReceivedItemCount(WOODS_OBELISK_SIGILS) >= 10 && lowestLevelReachedField.GetValue() >= 100)
+                {
+                    return; //let the player gain these floors on their own since they've "collected" the floors already
+                }
+                
                 lowestLevelReachedField.SetValue(10 * _archipelago.GetReceivedItemCount(WOODS_OBELISK_SIGILS));
                 var levelIndexedAt1 = level - 1;
 

--- a/StardewArchipelago/Locations/CodeInjections/Modded/MagicModInjections.cs
+++ b/StardewArchipelago/Locations/CodeInjections/Modded/MagicModInjections.cs
@@ -54,7 +54,7 @@ namespace StardewArchipelago.Locations.CodeInjections.Modded
 
         private static readonly Dictionary<ShopIdentification, PricedItem[]> craftsanityRecipes = new()
         {
-            { new ShopIdentification("AdventureGuild", "Marlon"), new[] { new PricedItem("Magic Elixir", 3000), new PricedItem("Travel Charm", 250) } },
+            { new ShopIdentification("AdventureGuild", "Marlon"), new[] { new PricedItem("Magic Elixir", 3000), new PricedItem("Travel Core", 250) } },
         };
 
 

--- a/StardewArchipelago/Locations/CodeInjections/Modded/SVE/SVECutsceneInjections.cs
+++ b/StardewArchipelago/Locations/CodeInjections/Modded/SVE/SVECutsceneInjections.cs
@@ -25,6 +25,7 @@ namespace StardewArchipelago.Locations.CodeInjections.Modded.SVE
         private const int IRIDIUM_BOMB_ID = 8050109;
         private const string LANCE_CHEST = "Lance's Diamond Wand";
         private const string MONSTER_ERADICATION_AP_PREFIX = "Monster Eradication: ";
+        private const string DEINFEST_AP_LOCATION = "Purify an Infested Lichtung";
         private static readonly List<string> voidSpirits = new(){
             MonsterName.SHADOW_BRUTE, MonsterName.SHADOW_SHAMAN, MonsterName.SHADOW_SNIPER, MonsterCategory.VOID_SPIRITS,
             string.Join("30 ",MonsterCategory.VOID_SPIRITS), string.Join("60 ",MonsterCategory.VOID_SPIRITS), 
@@ -133,12 +134,20 @@ namespace StardewArchipelago.Locations.CodeInjections.Modded.SVE
         {
             try
             {
+                if (!Game1.player.eventsSeen.Contains(1090508))
+                {
+                    return;
+                }
                 foreach (var voidSpirit in voidSpirits)
                 {
                     var locationName = $"{MONSTER_ERADICATION_AP_PREFIX}{voidSpirit}";
                     if (_locationChecker.IsLocationMissing(locationName))
                     {
                         _locationChecker.AddCheckedLocation(locationName);
+                    }
+                    if (_locationChecker.IsLocationMissing(DEINFEST_AP_LOCATION)) // Temp, as Void Spirits are on these maps
+                    {
+                        _locationChecker.AddCheckedLocation(DEINFEST_AP_LOCATION);
                     }
                 }
             }

--- a/StardewArchipelago/Locations/CodeInjections/Modded/SkullCavernInjections.cs
+++ b/StardewArchipelago/Locations/CodeInjections/Modded/SkullCavernInjections.cs
@@ -11,6 +11,7 @@ namespace StardewArchipelago.Locations.CodeInjections.Modded
     {
         public const string SKULL_CAVERN_ELEVATOR_ITEM = "Progressive Skull Cavern Elevator";
         public const string SKULL_CAVERN_FLOOR_LOCATION = "Skull Cavern: Floor {0}";
+        public const string SKULL_KEY = "Skull Key";
 
         private const int ELEVATOR_STEP = 25;
         private const int DIFFICULTY = 1;
@@ -35,6 +36,10 @@ namespace StardewArchipelago.Locations.CodeInjections.Modded
         {
             try
             {
+                if (!_archipelago.HasReceivedItem(SKULL_KEY))
+                {
+                    return true; // Don't bother updating anything until then.
+                }
                 var receivedElevators = _archipelago.GetReceivedItemCount(SKULL_CAVERN_ELEVATOR_ITEM);
                 elevatorStep = ELEVATOR_STEP;
                 difficulty = DIFFICULTY;
@@ -43,7 +48,10 @@ namespace StardewArchipelago.Locations.CodeInjections.Modded
                 {
                     _realDeepestMineLevel = Game1.player.deepestMineLevel;
                 }
-
+                if (receivedElevators >= 8 && Game1.player.deepestMineLevel >= 320)
+                {
+                    return true; //let the player gain these floors on their own since they've "collected" the floors already
+                }
                 var elevatorMaxLevel = (receivedElevators * ELEVATOR_STEP) + 120;
                 Game1.player.deepestMineLevel = elevatorMaxLevel;
 


### PR DESCRIPTION
Does the following:
- Fixes unintentional lack of inequality on excalibur check making it generally impossible.
- Fixes Travel Core typo
- Fixed mistake in void spirit goal check where it would likely do it immediately.
- Add DeepWoods Infested map to release if received.
- Lets players gain floors after reaching max floor count for DeepWoods and SCE.
- Fix bug where the elevator let you into skull cavern too early.