### PR TITLE
Fix Crafting and let Analyze work on DeepWoods meteors

### DIFF
--- a/StardewArchipelago/Locations/CodeInjections/Modded/MagicModInjections.cs
+++ b/StardewArchipelago/Locations/CodeInjections/Modded/MagicModInjections.cs
@@ -225,9 +225,9 @@ namespace StardewArchipelago.Locations.CodeInjections.Modded
             var tile = player.currentLocation.map.GetLayer("Buildings").Tiles[(int)tilePos.X, (int)tilePos.Y];
             if (tile != null && tile.TileIndex == MINE_LADDER)
                 spellsLearned.Add(ANALYZE_DESCEND_AP_LOCATION);
-            if (player.currentLocation is Farm farm)
+            if (player.currentLocation is Farm farm || player.currentLocation.Name.Contains("DeepWoods"))
             {
-                foreach (var clump in farm.resourceClumps)
+                foreach (var clump in player.currentLocation.resourceClumps)
                 {
                     if (clump.parentSheetIndex.Value == CROP_TILE &&
                         new Rectangle((int)clump.tile.Value.X, (int)clump.tile.Value.Y, clump.width.Value, clump.height.Value).Contains((int)tilePos.X, (int)tilePos.Y))

--- a/StardewArchipelago/Locations/CodeInjections/Modded/ModdedEventInjections.cs
+++ b/StardewArchipelago/Locations/CodeInjections/Modded/ModdedEventInjections.cs
@@ -93,7 +93,7 @@ namespace StardewArchipelago.Locations.CodeInjections.Modded
                     return true;
                 }
 
-                _locationChecker.AddCheckedLocation($"{eventCooking[__instance.id]}{RECIPE_SUFFIX}");
+                _locationChecker.AddCheckedLocation($"{eventCrafting[__instance.id]}{RECIPE_SUFFIX}");
                 __instance.CurrentCommand++;
                 return false; // don't run original logic
 

--- a/StardewArchipelago/ModEntry.cs
+++ b/StardewArchipelago/ModEntry.cs
@@ -377,6 +377,10 @@ namespace StardewArchipelago
                     Game1.player.cookingRecipes.Remove("Lucky Lunch");
                 }
             }
+            if (_archipelago.HasReceivedItem("Magic Elixir Recipe") & !Game1.player.cookingRecipes.ContainsKey("Magic Elixir"))
+            {
+                Game1.player.cookingRecipes.Add("Magic Elixir", 0); // Its a cooking recipe.
+            }
             // Fix to remove dupes in Railroad Boulder
             if (!_archipelago.SlotData.Mods.HasMod(ModNames.SVE))
             {


### PR DESCRIPTION
Quick fix:
- checks correct dictionary for ginger tincture.
- Lets Analyze work on meteors found in DeepWoods
- Bugfix due to backend where the player will get the magic elixir cooking recipe on save loaded.