### PR TITLE
Move Archaeology support to 1.6.0

### DIFF
--- a/Documentation/Supported Mods.md
+++ b/Documentation/Supported Mods.md
@@ -25,7 +25,7 @@ Skills:
 - [Magic](https://www.nexusmods.com/stardewvalley/mods/2007), by spacechase0, Version 0.8.2
 - [Luck Skill](https://www.nexusmods.com/stardewvalley/mods/521), by spacechase0, Version 1.2.4
 - [Socializing Skill](https://www.nexusmods.com/stardewvalley/mods/14142), by drbirbdev, Version 1.1.5
-- [Archaeology](https://www.nexusmods.com/stardewvalley/mods/15793), by drbirbdev, Version 1.5.0
+- [Archaeology](https://www.nexusmods.com/stardewvalley/mods/15793), by drbirbdev, Version 1.6.0
 - [Cooking Skill](https://www.nexusmods.com/stardewvalley/mods/522), by spacechase0, Version 1.4.5
 - [Binning Skill](https://www.nexusmods.com/stardewvalley/mods/14073), by drbirbdev, Version 1.2.7
 

--- a/StardewArchipelago/Constants/Modded/ModVersions.cs
+++ b/StardewArchipelago/Constants/Modded/ModVersions.cs
@@ -7,7 +7,7 @@ namespace StardewArchipelago.Constants.Modded
         public static readonly Dictionary<string, string> Versions = new Dictionary<string, string>()
         {
             { ModNames.ALEC, "2.1.0"},
-            { ModNames.ARCHAEOLOGY, "1.5.0"},
+            { ModNames.ARCHAEOLOGY, "1.6.0"},
             { ModNames.AYEISHA, "0.6.2-alpha"},
             { ModNames.BIGGER_BACKPACK, "6.0.0"},
             { ModNames.BINNING, "1.2.7"},

--- a/StardewArchipelago/Stardew/NameMapping/NameSimplifier.cs
+++ b/StardewArchipelago/Stardew/NameMapping/NameSimplifier.cs
@@ -28,7 +28,7 @@ namespace StardewArchipelago.Stardew.NameMapping
             if (name.Contains("moonslime.excavation."))
             {
                 TextInfo ti = CultureInfo.CurrentCulture.TextInfo;
-                var displayName = ti.ToTitleCase(item.DisplayName.Replace("Woooden", "Wooden"));
+                var displayName = ti.ToTitleCase(item.DisplayName);
                 if (name.Contains("strange_doll_green"))
                 {
                     displayName += " (Green)";
@@ -36,10 +36,6 @@ namespace StardewArchipelago.Stardew.NameMapping
                 if (name.Contains("trilobite")) // Temporary fix.
                 {
                     displayName = displayName.Replace("Trilobite Fossil", "Trilobite");
-                }
-                if (displayName.Contains("Rusty Sur"))
-                {
-                    displayName = displayName.Replace("Sur", "Spur");
                 }
                 name = displayName;
             }

--- a/StardewArchipelago/StardewArchipelago.csproj
+++ b/StardewArchipelago/StardewArchipelago.csproj
@@ -4,7 +4,6 @@
     <TargetFramework>net5.0</TargetFramework>
     <ApplicationManifest>manifest.json</ApplicationManifest>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
-    <GamePath>/mnt/Games and Media Collection/StardewBackup</GamePath>
     <EnableHarmony>true</EnableHarmony>
   </PropertyGroup>
 

--- a/StardewArchipelago/StardewArchipelago.csproj
+++ b/StardewArchipelago/StardewArchipelago.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>net5.0</TargetFramework>
     <ApplicationManifest>manifest.json</ApplicationManifest>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
+    <GamePath>/mnt/Games and Media Collection/StardewBackup</GamePath>
     <EnableHarmony>true</EnableHarmony>
   </PropertyGroup>
 


### PR DESCRIPTION
Fixes Archaeology to have 1.6.0 support.  Removes a few needless tests and conversions as they are no longer necessary.