### PR TITLE
Fix Zic alias.

### DIFF
--- a/StardewArchipelago/Constants/Vanilla/NameAliases.cs
+++ b/StardewArchipelago/Constants/Vanilla/NameAliases.cs
@@ -33,7 +33,7 @@ namespace StardewArchipelago.Constants.Vanilla
             { "MarlonFay", "Marlon" },
             { "GuntherSilvian", "Gunther" },
             { "MorrisTod", "Morris" },
-            { "Goblin", "Zic" },
+            { "Aimon111.WitchSwampOverhaulCP_GoblinZic", "Zic" },
             { "ichortower.HatMouseLacey_Lacey", "Lacey"},
             { "SPB_Alec", "Alec"},
         };


### PR DESCRIPTION
Zic's internal name was changed:

- Goblin -> {{ModId}}_GoblinZic

As the ModId is Aimon111.WitchSwampOverhaulCP, updated to Aimon111.WitchSwampOverhaulCP_GoblinZic.