### PR TITLE
Don't apply the : check in the replace.

### DIFF
--- a/StardewArchipelago/Stardew/NameMapping/NameSimplifier.cs
+++ b/StardewArchipelago/Stardew/NameMapping/NameSimplifier.cs
@@ -79,7 +79,7 @@ namespace StardewArchipelago.Stardew.NameMapping
 
         private string FixArchaeologyLocationInconsistentNaming(string itemName)
         {
-            itemName = itemName.Replace("Wood Display: ", "Wooden Display: ");
+            itemName = itemName.Replace("Wood Display", "Wooden Display");
             itemName = itemName.Replace("Strange Doll Green", "Strange Doll (Green)");
             itemName = itemName.Replace("Strange Doll Yellow", "Strange Doll");
             if (Constants.Modded.ModItemNameTranslations.ArchaeologyInternalToDisplay.TryGetValue(itemName, out var fixedName))


### PR DESCRIPTION
It just drops the ": " from Wooden Display because the item itself was incorrect.  Was done to try to avoid false positives but I guess I am over-worried.