### PR TITLE
Fix Archaeology Name Translations

### DIFF
--- a/StardewArchipelago/Constants/Modded/ModItemNameTranslations.cs
+++ b/StardewArchipelago/Constants/Modded/ModItemNameTranslations.cs
@@ -10,7 +10,8 @@ namespace StardewArchipelago.Constants.Modded
             {"Hardwood Display: Trilobite", "Hardwood Display: Trilobite Fossil"},
             {"Rusted Scrap", "Scrap Rust"},
             {"Rust Path", "Rusty Path"},
-            {"Ancient Dwarven Volcano Simulator", "Dwarf Gadget: Infinite Volcano Simulation"}
+            {"Ancient Dwarven Volcano Simulator", "Dwarf Gadget: Infinite Volcano Simulation"},
+            {"moonslime.Archaeology.bone_path", "Bone Path"},
         };
     }
 }

--- a/StardewArchipelago/Constants/Modded/ModItemNameTranslations.cs
+++ b/StardewArchipelago/Constants/Modded/ModItemNameTranslations.cs
@@ -6,7 +6,6 @@ namespace StardewArchipelago.Constants.Modded
     {
         public static readonly Dictionary<string, string> ArchaeologyInternalToDisplay = new()
         {
-            {"Hardwood Display: Snake Vertabra", "Hardwood Display: Snake Vertebrae"},
             {"Hardwood Display: Trilobite", "Hardwood Display: Trilobite Fossil"},
             {"Rusted Scrap", "Scrap Rust"},
             {"Rust Path", "Rusty Path"},

--- a/StardewArchipelago/Stardew/NameMapping/NameSimplifier.cs
+++ b/StardewArchipelago/Stardew/NameMapping/NameSimplifier.cs
@@ -86,6 +86,10 @@ namespace StardewArchipelago.Stardew.NameMapping
             {
                 itemName = fixedName;
             }
+            if (!itemName.Contains("Vertebrae")) // Basically "if it has the typo".
+            {
+                itemName = itemName.Replace("Vertabra", "Vertebrae");
+            }
             return itemName;
         }
 


### PR DESCRIPTION
Seems this item in particular wants to be named moonslime.Archaeology.bone_path, when others don't for checking craftsanity.