### PR TITLE
Add Bugfix for SVE shipsanity for async

### DIFF
--- a/StardewArchipelago/Locations/CodeInjections/Vanilla/ShippingInjections.cs
+++ b/StardewArchipelago/Locations/CodeInjections/Vanilla/ShippingInjections.cs
@@ -104,7 +104,7 @@ namespace StardewArchipelago.Locations.CodeInjections.Vanilla
                 }
                 else
                 {    
-                    DoBugsCleanup(shippedItem, out var wasSuccessful);
+                    var wasSuccessful = DoBugsCleanup(shippedItem);
                     if (wasSuccessful)
                     {
                         continue;
@@ -114,8 +114,9 @@ namespace StardewArchipelago.Locations.CodeInjections.Vanilla
             }
         }
 
-        private void DoBugsCleanup(Item shippedItem, out bool wasSuccessful)
+        private bool DoBugsCleanup(Item shippedItem)
         {
+            // In the beta async, backend names for SVE shippables are the internal names.  This fixes the mistake ONLY for that beta async.  Remove after it.
             var name = _nameSimplifier.GetSimplifiedName(shippedItem);
             var sveMappedItems = new List<string>() {"Smelly Rafflesia", "Bearberrys", "Big Conch", "Dried Sand Dollar", "Lucky Four Leaf Clover", "Ancient Ferns Seed"};
             if (sveMappedItems.Contains(name))
@@ -125,11 +126,10 @@ namespace StardewArchipelago.Locations.CodeInjections.Vanilla
                 {
                     _monitor.Log($"Bugfix caught this for the beta async.  If this isn't that game, let the developers know there's a bug!", LogLevel.Warn);
                     _locationChecker.AddCheckedLocation(apLocation);
-                    wasSuccessful = true;
-                    return;
+                    return true;
                 }
             }
-            wasSuccessful = false;
+            return false;
         }
     }
 }

--- a/StardewArchipelago/Locations/CodeInjections/Vanilla/ShippingInjections.cs
+++ b/StardewArchipelago/Locations/CodeInjections/Vanilla/ShippingInjections.cs
@@ -103,10 +103,33 @@ namespace StardewArchipelago.Locations.CodeInjections.Vanilla
                     _locationChecker.AddCheckedLocation(apLocation);
                 }
                 else
-                {
+                {    
+                    DoBugsCleanup(shippedItem, out var wasSuccessful);
+                    if (wasSuccessful)
+                    {
+                        continue;
+                    }
                     _monitor.Log($"Unrecognized Shipsanity Location: {name} [{shippedItem.ParentSheetIndex}]", LogLevel.Error);
                 }
             }
+        }
+
+        private void DoBugsCleanup(Item shippedItem, out bool wasSuccessful)
+        {
+            var name = _nameSimplifier.GetSimplifiedName(shippedItem);
+            var sveMappedItems = new List<string>() {"Smelly Rafflesia", "Bearberrys", "Big Conch", "Dried Sand Dollar", "Lucky Four Leaf Clover", "Ancient Ferns Seed"};
+            if (sveMappedItems.Contains(name))
+            {
+                var apLocation = $"{SHIPSANITY_PREFIX}{name}";
+                if (_archipelago.GetLocationId(apLocation) > -1)
+                {
+                    _monitor.Log($"Bugfix caught this for the beta async.  If this isn't that game, let the developers know there's a bug!", LogLevel.Warn);
+                    _locationChecker.AddCheckedLocation(apLocation);
+                    wasSuccessful = true;
+                    return;
+                }
+            }
+            wasSuccessful = false;
         }
     }
 }


### PR DESCRIPTION
This is an addendum to the previous.

All this does is, if shipsanity fails to ship these items, it'll try again with the internal name for the SVE items only.  If it fails, it fails as normal.  There's an additional warning added to tell the user if they see the text and they aren't in the beta async to let us know about it since it shouldn't be called.