### PR TITLE
Mastery Menu Fix

### DIFF
--- a/StardewArchipelago/Locations/CodeInjections/Vanilla/MasteriesInjections.cs
+++ b/StardewArchipelago/Locations/CodeInjections/Vanilla/MasteriesInjections.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using StardewArchipelago.Archipelago;
 using StardewModdingAPI;
 using StardewValley;
+using StardewValley.Constants;
 using StardewValley.Menus;
 using xTile.Dimensions;
 
@@ -96,7 +97,17 @@ namespace StardewArchipelago.Locations.CodeInjections.Vanilla
 
         private static void PerformActionMasteryCaveSkill(Skill skill)
         {
+
             if (_locationChecker.IsLocationMissing($"{skill} {MASTERY}"))
+            {
+                int originalStat = (int)Game1.player.stats.Get(StatKeys.Mastery((int)skill));
+
+                Game1.player.stats.Set(StatKeys.Mastery((int)skill), 0);
+                Game1.activeClickableMenu = new MasteryTrackerMenu((int)skill);
+                Game1.player.stats.Set(StatKeys.Mastery((int)skill), originalStat);
+
+            }
+            else
             {
                 Game1.activeClickableMenu = new MasteryTrackerMenu((int)skill);
             }

--- a/StardewArchipelago/Properties/launchSettings.json
+++ b/StardewArchipelago/Properties/launchSettings.json
@@ -1,0 +1,7 @@
+{
+  "profiles": {
+    "StardewArchipelago": {
+      "commandName": "Project"
+    }
+  }
+}

--- a/StardewArchipelago/Properties/launchSettings.json
+++ b/StardewArchipelago/Properties/launchSettings.json
@@ -1,7 +1,0 @@
-{
-  "profiles": {
-    "StardewArchipelago": {
-      "commandName": "Project"
-    }
-  }
-}


### PR DESCRIPTION
Added logic to temporarily set the player mastery state to 0 to allow the claim button to render properly when mastery location has not been claimed yet but the item has been received