### PR TITLE
Upgrade item tooltip marking

### DIFF
--- a/StardewArchipelago/Constants/Locations/NameMatching.cs
+++ b/StardewArchipelago/Constants/Locations/NameMatching.cs
@@ -36,5 +36,40 @@ namespace StardewArchipelago.Constants.Locations
             { "Trash", new[] { "Trash Can Upgrade" } },
             { "Turnip", new[] { "Rarecrow #1 (Turnip Head)" } },
         };
+
+        // TODO expand that list, it basically only has quests currently
+        public static readonly Dictionary<string, string[]> ItemNeededForLocations = new()
+        {
+            { "Albacore", new[] { "Fish Stew" } },
+            { "Amaranth", new[] { "Cow's Delight" } },
+            { "Amethyst", new[] { "Clint's Attempt" } },
+            { "Apricot", new[] { "Fresh Fruit" } },
+            { "Battery Pack", new[] { "Pam Needs Juice", "Repair Ticket Machine" } },
+            { "Beet", new[] { "The Mysterious Qi" } },
+            { "Cauliflower", new[] { "Jodi's Request" } },
+            { "Cave Carrot", new[] { "Marnie's Request" } },
+            { "Coconut", new[] { "Exotic Spirits" } },
+            { "Hardwood", new[] { "Repair Boat Hull", "Robin's Request", "The Giant Stump" } },
+            { "Hot Pepper", new[] { "Knee Therapy" } },
+            { "Iridium Bar", new[] { "Repair Boat Anchor", "Staff of Power" } },
+            { "Iron Bar", new[] { "A Favor For Clint" } },
+            { "Largemouth Bass", new[] { "Fish Casserole" } },
+            { "Leek", new[] { "Gifts For George", "Granny's Gift" } },
+            { "Maple Syrup", new[] { "Strange Note" } },
+            { "Melon", new[] { "Crop Research" } },
+            { "Pale Ale", new[] { "Pam Is Thirsty" } },
+            { "Potato", new[] { "The Strong Stuff" } },
+            { "Prismatic Shard", new[] { "Galaxy Sword Shrine" } },
+            { "Pufferfish", new[] { "Aquatic Research" } },
+            { "Pumpkin", new[] { "Carving Pumpkins" } },
+            { "Rainbow Shell", new[] { "The Mysterious Qi" } },
+            { "Sashimi", new[] { "Pierre's Notice" } },
+            { "Solar Essence", new[] { "The Mysterious Qi" } },
+            { "Starfruit", new[] { "A Soldier's Star" } },
+            { "Sweet Gem Berry", new[] { "Old Master Cannoli" } },
+            { "Truffle Oil", new[] { "Mayor's Need" } },
+            { "Void Essence", new[] { "A Dark Reagent" } },
+            { "Void Mayonnaise", new[] { "Goblin Problem" } },
+        };
     }
 }

--- a/StardewArchipelago/GameModifications/Tooltips/ItemTooltipInjections.cs
+++ b/StardewArchipelago/GameModifications/Tooltips/ItemTooltipInjections.cs
@@ -13,6 +13,8 @@ using StardewModdingAPI;
 using StardewValley;
 using StardewValley.Objects;
 using Object = StardewValley.Object;
+using StardewArchipelago.Constants.Locations;
+using System.Collections.Generic;
 
 namespace StardewArchipelago.GameModifications.Tooltips
 {
@@ -81,11 +83,14 @@ namespace StardewArchipelago.GameModifications.Tooltips
             }
 
             var simplifiedName = _nameSimplifier.GetSimplifiedName(item);
-            var allUncheckedLocations = _locationChecker.GetAllLocationsNotCheckedContainingWord(simplifiedName);
+            var allUncheckedLocationsFilteredByName = _locationChecker.GetAllLocationsNotCheckedContainingWord(simplifiedName);
+            var extraLocationsThatNeedItem = NameMatching.ItemNeededForLocations.GetValueOrDefault(simplifiedName);
+            var extraUncheckedLocationsThatNeedItem = _locationChecker.GetAllLocationsNotCheckedThatOverlap(extraLocationsThatNeedItem);
 
-            allUncheckedLocations = FilterLocationsBasedOnConfig(allUncheckedLocations);
+            var allUncheckedLocationsUsingItem = allUncheckedLocationsFilteredByName.Union(extraUncheckedLocationsThatNeedItem).ToArray();
+            allUncheckedLocationsUsingItem = FilterLocationsBasedOnConfig(allUncheckedLocationsUsingItem);
 
-            if (!allUncheckedLocations.Any())
+            if (!allUncheckedLocationsUsingItem.Any())
             {
                 return true;
             }
@@ -112,11 +117,14 @@ namespace StardewArchipelago.GameModifications.Tooltips
                 }
 
                 var simplifiedName = _nameSimplifier.GetSimplifiedName(__instance);
-                var allUncheckedLocations = _locationChecker.GetAllLocationsNotCheckedContainingWord(simplifiedName);
+                var allUncheckedLocationsFilteredByName = _locationChecker.GetAllLocationsNotCheckedContainingWord(simplifiedName);
+                var extraLocationsThatNeedItem = NameMatching.ItemNeededForLocations.GetValueOrDefault(simplifiedName);
+                var extraUncheckedLocationsThatNeedItem = _locationChecker.GetAllLocationsNotCheckedThatOverlap(extraLocationsThatNeedItem);
 
-                allUncheckedLocations = FilterLocationsBasedOnConfig(allUncheckedLocations);
+                var allUncheckedLocationsUsingItem = allUncheckedLocationsFilteredByName.Union(extraUncheckedLocationsThatNeedItem).ToArray();
+                allUncheckedLocationsUsingItem = FilterLocationsBasedOnConfig(allUncheckedLocationsUsingItem);
 
-                foreach (var uncheckedLocation in allUncheckedLocations)
+                foreach (var uncheckedLocation in allUncheckedLocationsUsingItem)
                 {
                     __result += $"{Environment.NewLine}{uncheckedLocation}";
                 }

--- a/StardewArchipelago/Locations/StardewLocationChecker.cs
+++ b/StardewArchipelago/Locations/StardewLocationChecker.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Linq;
 using KaitoKid.ArchipelagoUtilities.Net;
 using KaitoKid.ArchipelagoUtilities.Net.Client;
 using KaitoKid.ArchipelagoUtilities.Net.Interfaces;
@@ -64,6 +65,11 @@ namespace StardewArchipelago.Locations
         public string[] GetAllLocationsNotCheckedContainingWord(string wordFilter)
         {
             return _locationNameMatcher.GetAllLocationsContainingWord(GetAllLocationsNotChecked(), wordFilter);
+        }
+
+        public string[] GetAllLocationsNotCheckedThatOverlap(string[] locations)
+        {
+            return GetAllLocationsNotChecked().Intersect(locations).ToArray();
         }
 
         public bool IsAnyLocationNotChecked(string filter)


### PR DESCRIPTION
Lays a framework to add non-trivial locations to the list an item has in its tooltip that says where it's needed. Should be easily expandable beyond only quests, but this proves the concept.