### PR TITLE
Archaeology update

### DIFF
--- a/StardewArchipelago/Constants/Modded/ModBookIds.cs
+++ b/StardewArchipelago/Constants/Modded/ModBookIds.cs
@@ -1,7 +1,30 @@
+using System.Collections.Generic;
+
 namespace StardewArchipelago.Constants.Modded
 {
     internal class ModBookIds
     {
         public static readonly string DIGGING_LIKE_WORMS = "moonslime.Archaeology.skill_book";
+    }
+}
+
+namespace StardewArchipelago.Constants.Modded
+{
+    public static class ModPowerBooks
+    {
+        // Mod Books
+        public const string DIGGING_LIKE_WORMS = "Digging Like Worms";
+
+        public static readonly Dictionary<string, string> BookIdsToNames = new()
+        {
+            // Mod Books
+            { ModBookIds.DIGGING_LIKE_WORMS, DIGGING_LIKE_WORMS },
+        };
+
+        public static readonly Dictionary<string, string> BookNamesToIds = new()
+        {
+            // Mod Books
+            { DIGGING_LIKE_WORMS, ModBookIds.DIGGING_LIKE_WORMS },
+        };
     }
 }

--- a/StardewArchipelago/Constants/Modded/ModBookIds.cs
+++ b/StardewArchipelago/Constants/Modded/ModBookIds.cs
@@ -1,0 +1,7 @@
+namespace StardewArchipelago.Constants.Modded
+{
+    internal class ModBookIds
+    {
+        public static readonly string DIGGING_LIKE_WORMS = "moonslime.Archaeology.skill_book";
+    }
+}

--- a/StardewArchipelago/Constants/Modded/ModBookIds.cs
+++ b/StardewArchipelago/Constants/Modded/ModBookIds.cs
@@ -5,25 +5,14 @@ namespace StardewArchipelago.Constants.Modded
     internal class ModBookIds
     {
         public static readonly string DIGGING_LIKE_WORMS = "moonslime.Archaeology.skill_book";
-    }
-}
 
-namespace StardewArchipelago.Constants.Modded
-{
-    public static class ModPowerBooks
-    {
-        // Mod Books
-        public const string DIGGING_LIKE_WORMS = "Digging Like Worms";
-
-        public static readonly Dictionary<string, string> BookIdsToNames = new()
+        public static readonly Dictionary<string, string> ModBookIdsToNames = new()
         {
-            // Mod Books
             { ModBookIds.DIGGING_LIKE_WORMS, DIGGING_LIKE_WORMS },
         };
 
-        public static readonly Dictionary<string, string> BookNamesToIds = new()
+        public static readonly Dictionary<string, string> ModBookNamesToIds = new()
         {
-            // Mod Books
             { DIGGING_LIKE_WORMS, ModBookIds.DIGGING_LIKE_WORMS },
         };
     }

--- a/StardewArchipelago/Constants/Modded/ModBookIds.cs
+++ b/StardewArchipelago/Constants/Modded/ModBookIds.cs
@@ -5,15 +5,5 @@ namespace StardewArchipelago.Constants.Modded
     internal class ModBookIds
     {
         public static readonly string DIGGING_LIKE_WORMS = "moonslime.Archaeology.skill_book";
-
-        public static readonly Dictionary<string, string> ModBookIdsToNames = new()
-        {
-            { ModBookIds.DIGGING_LIKE_WORMS, DIGGING_LIKE_WORMS },
-        };
-
-        public static readonly Dictionary<string, string> ModBookNamesToIds = new()
-        {
-            { DIGGING_LIKE_WORMS, ModBookIds.DIGGING_LIKE_WORMS },
-        };
     }
 }

--- a/StardewArchipelago/Constants/Modded/ModVersions.cs
+++ b/StardewArchipelago/Constants/Modded/ModVersions.cs
@@ -30,7 +30,8 @@ namespace StardewArchipelago.Constants.Modded
             { ModNames.TRACTOR, $"4.21.{WILDCARD}" },
             //{ ModNames.WELLWICK, "1.0.0" },
             //{ ModNames.YOBA, "1.0.0" },
-            { ModNames.SVE, $"1.15.10" },
+            { ModNames.SVE, $"1.14.{WILDCARD}" },
+            //{ ModNames.SVE, $"1.15.10" }, less SVE versioning dirty edits 
             { ModNames.DISTANT_LANDS, $"2.2.{WILDCARD}" },
             { ModNames.LACEY, $"1.4.{WILDCARD}" },
             //{ ModNames.BOARDING_HOUSE, "4.0.16" },
@@ -53,8 +54,8 @@ namespace StardewArchipelago.Constants.Modded
             {
                 ModNames.SVE, new List<ContentPatcherRequirement>()
                 {
-                    //new(ModNames.AP_CP_SVE_PATCH, "2.1.x"),
-                    //new(ModNames.AP_CP_SVE, "1.14.46"),
+                    new(ModNames.AP_CP_SVE_PATCH, "2.1.x"),
+                    new(ModNames.AP_CP_SVE, "1.14.46"),
                 }
             },
         };

--- a/StardewArchipelago/Constants/Modded/ModVersions.cs
+++ b/StardewArchipelago/Constants/Modded/ModVersions.cs
@@ -15,7 +15,7 @@ namespace StardewArchipelago.Constants.Modded
             { ModNames.BIGGER_BACKPACK, $"7.3.{WILDCARD}" },
             { ModNames.BINNING, $"2.1.{WILDCARD}" },
             //{ ModNames.COOKING, "1.4.5" },
-            //{ ModNames.DEEP_WOODS, "3.1.0-beta" },
+            //{ ModNames.DEEP_WOODS, "4.0.1-alpha" },
             //{ ModNames.DELORES, "1.1.2" },
             //{ ModNames.EUGENE, "1.3.1" },
             { ModNames.JASPER, $"1.8.3" },
@@ -30,7 +30,7 @@ namespace StardewArchipelago.Constants.Modded
             { ModNames.TRACTOR, $"4.21.{WILDCARD}" },
             //{ ModNames.WELLWICK, "1.0.0" },
             //{ ModNames.YOBA, "1.0.0" },
-            { ModNames.SVE, $"1.14.{WILDCARD}" },
+            { ModNames.SVE, $"1.15.10" },
             { ModNames.DISTANT_LANDS, $"2.2.{WILDCARD}" },
             { ModNames.LACEY, $"1.4.{WILDCARD}" },
             //{ ModNames.BOARDING_HOUSE, "4.0.16" },
@@ -53,8 +53,8 @@ namespace StardewArchipelago.Constants.Modded
             {
                 ModNames.SVE, new List<ContentPatcherRequirement>()
                 {
-                    new(ModNames.AP_CP_SVE_PATCH, "2.1.x"),
-                    new(ModNames.AP_CP_SVE, "1.14.46"),
+                    //new(ModNames.AP_CP_SVE_PATCH, "2.1.x"),
+                    //new(ModNames.AP_CP_SVE, "1.14.46"),
                 }
             },
         };

--- a/StardewArchipelago/Constants/Modded/ModVersions.cs
+++ b/StardewArchipelago/Constants/Modded/ModVersions.cs
@@ -10,7 +10,7 @@ namespace StardewArchipelago.Constants.Modded
         {
             { ModNames.ALEC, $"2.2.{WILDCARD}" },
             { ModNames.ALECTO, $"1.1.{WILDCARD}" },
-            { ModNames.ARCHAEOLOGY, $"2.12.1" },
+            { ModNames.ARCHAEOLOGY, $"2.14.1" },
             { ModNames.AYEISHA, $"0.7.{WILDCARD}" },
             { ModNames.BIGGER_BACKPACK, $"7.3.{WILDCARD}" },
             { ModNames.BINNING, $"2.1.{WILDCARD}" },

--- a/StardewArchipelago/Constants/Vanilla/PowerBooks.cs
+++ b/StardewArchipelago/Constants/Vanilla/PowerBooks.cs
@@ -1,5 +1,4 @@
-﻿using StardewArchipelago.Constants.Modded;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 
 namespace StardewArchipelago.Constants.Vanilla
 {
@@ -32,8 +31,6 @@ namespace StardewArchipelago.Constants.Vanilla
         public const string MINING_MONTHLY = "Mining Monthly";
         public const string COMBAT_QUARTERLY = "Combat Quarterly";
         public const string QUEEN_OF_SAUCE_COOKBOOK = "Queen Of Sauce Cookbook";
-        // Mod Books
-        public const string DIGGING_LIKE_WORMS = "Digging Like Worms";
 
         public static readonly Dictionary<string, string> BookIdsToNames = new()
         {
@@ -63,8 +60,6 @@ namespace StardewArchipelago.Constants.Vanilla
             { ObjectIds.MINING_MONTHLY, MINING_MONTHLY },
             { ObjectIds.COMBAT_QUARTERLY, COMBAT_QUARTERLY },
             { ObjectIds.QUEEN_OF_SAUCE_COOKBOOK, QUEEN_OF_SAUCE_COOKBOOK },
-            // Mod Books
-            { ModBookIds.DIGGING_LIKE_WORMS, DIGGING_LIKE_WORMS },
         };
 
         public static readonly Dictionary<string, string> BookNamesToIds = new()
@@ -95,8 +90,6 @@ namespace StardewArchipelago.Constants.Vanilla
             { MINING_MONTHLY, ObjectIds.MINING_MONTHLY },
             { COMBAT_QUARTERLY, ObjectIds.COMBAT_QUARTERLY },
             { QUEEN_OF_SAUCE_COOKBOOK, ObjectIds.QUEEN_OF_SAUCE_COOKBOOK },
-            // Mod Books
-            { DIGGING_LIKE_WORMS, ModBookIds.DIGGING_LIKE_WORMS },
         };
 
 
@@ -106,26 +99,5 @@ namespace StardewArchipelago.Constants.Vanilla
         "Book_Horse" "Horse: The Book"
         "Book_WildSeeds" "Ways Of The Wild" "Raccoon Journal"
          */
-    }
-}
-
-namespace StardewArchipelago.Constants.Modded
-{
-    public static class ModPowerBooks
-    {
-        // Mod Books
-        public const string DIGGING_LIKE_WORMS = "Digging Like Worms";
-
-        public static readonly Dictionary<string, string> BookIdsToNames = new()
-        {
-            // Mod Books
-            { ModBookIds.DIGGING_LIKE_WORMS, DIGGING_LIKE_WORMS },
-        };
-
-        public static readonly Dictionary<string, string> BookNamesToIds = new()
-        {
-            // Mod Books
-            { DIGGING_LIKE_WORMS, ModBookIds.DIGGING_LIKE_WORMS },
-        };
     }
 }

--- a/StardewArchipelago/Constants/Vanilla/PowerBooks.cs
+++ b/StardewArchipelago/Constants/Vanilla/PowerBooks.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using StardewArchipelago.Constants.Modded;
 
 namespace StardewArchipelago.Constants.Vanilla
 {
@@ -31,6 +32,8 @@ namespace StardewArchipelago.Constants.Vanilla
         public const string MINING_MONTHLY = "Mining Monthly";
         public const string COMBAT_QUARTERLY = "Combat Quarterly";
         public const string QUEEN_OF_SAUCE_COOKBOOK = "Queen Of Sauce Cookbook";
+        // Mod Books
+        public const string DIGGING_LIKE_WORMS = "Digging Like Worms";
 
         public static readonly Dictionary<string, string> BookIdsToNames = new()
         {
@@ -60,6 +63,8 @@ namespace StardewArchipelago.Constants.Vanilla
             { ObjectIds.MINING_MONTHLY, MINING_MONTHLY },
             { ObjectIds.COMBAT_QUARTERLY, COMBAT_QUARTERLY },
             { ObjectIds.QUEEN_OF_SAUCE_COOKBOOK, QUEEN_OF_SAUCE_COOKBOOK },
+            // Modded
+            { ModBookIds.DIGGING_LIKE_WORMS, DIGGING_LIKE_WORMS },
         };
 
         public static readonly Dictionary<string, string> BookNamesToIds = new()
@@ -90,6 +95,8 @@ namespace StardewArchipelago.Constants.Vanilla
             { MINING_MONTHLY, ObjectIds.MINING_MONTHLY },
             { COMBAT_QUARTERLY, ObjectIds.COMBAT_QUARTERLY },
             { QUEEN_OF_SAUCE_COOKBOOK, ObjectIds.QUEEN_OF_SAUCE_COOKBOOK },
+            //Modded
+            { DIGGING_LIKE_WORMS, ModBookIds.DIGGING_LIKE_WORMS },
         };
 
 

--- a/StardewArchipelago/Constants/Vanilla/PowerBooks.cs
+++ b/StardewArchipelago/Constants/Vanilla/PowerBooks.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using StardewArchipelago.Constants.Modded;
+using System.Collections.Generic;
 
 namespace StardewArchipelago.Constants.Vanilla
 {
@@ -31,6 +32,8 @@ namespace StardewArchipelago.Constants.Vanilla
         public const string MINING_MONTHLY = "Mining Monthly";
         public const string COMBAT_QUARTERLY = "Combat Quarterly";
         public const string QUEEN_OF_SAUCE_COOKBOOK = "Queen Of Sauce Cookbook";
+        // Mod Books
+        public const string DIGGING_LIKE_WORMS = "Digging Like Worms";
 
         public static readonly Dictionary<string, string> BookIdsToNames = new()
         {
@@ -60,6 +63,8 @@ namespace StardewArchipelago.Constants.Vanilla
             { ObjectIds.MINING_MONTHLY, MINING_MONTHLY },
             { ObjectIds.COMBAT_QUARTERLY, COMBAT_QUARTERLY },
             { ObjectIds.QUEEN_OF_SAUCE_COOKBOOK, QUEEN_OF_SAUCE_COOKBOOK },
+            // Mod Books
+            { ModBookIds.DIGGING_LIKE_WORMS, DIGGING_LIKE_WORMS },
         };
 
         public static readonly Dictionary<string, string> BookNamesToIds = new()
@@ -90,6 +95,8 @@ namespace StardewArchipelago.Constants.Vanilla
             { MINING_MONTHLY, ObjectIds.MINING_MONTHLY },
             { COMBAT_QUARTERLY, ObjectIds.COMBAT_QUARTERLY },
             { QUEEN_OF_SAUCE_COOKBOOK, ObjectIds.QUEEN_OF_SAUCE_COOKBOOK },
+            // Mod Books
+            { DIGGING_LIKE_WORMS, ModBookIds.DIGGING_LIKE_WORMS },
         };
 
 
@@ -99,5 +106,26 @@ namespace StardewArchipelago.Constants.Vanilla
         "Book_Horse" "Horse: The Book"
         "Book_WildSeeds" "Ways Of The Wild" "Raccoon Journal"
          */
+    }
+}
+
+namespace StardewArchipelago.Constants.Modded
+{
+    public static class ModPowerBooks
+    {
+        // Mod Books
+        public const string DIGGING_LIKE_WORMS = "Digging Like Worms";
+
+        public static readonly Dictionary<string, string> BookIdsToNames = new()
+        {
+            // Mod Books
+            { ModBookIds.DIGGING_LIKE_WORMS, DIGGING_LIKE_WORMS },
+        };
+
+        public static readonly Dictionary<string, string> BookNamesToIds = new()
+        {
+            // Mod Books
+            { DIGGING_LIKE_WORMS, ModBookIds.DIGGING_LIKE_WORMS },
+        };
     }
 }

--- a/StardewArchipelago/Locations/CodeInjections/Vanilla/BookInjections.cs
+++ b/StardewArchipelago/Locations/CodeInjections/Vanilla/BookInjections.cs
@@ -161,7 +161,7 @@ namespace StardewArchipelago.Locations.CodeInjections.Vanilla
         {
             PlayReadBookAnimation(book, location);
 
-            var possibleNames = new[] { book.Name, PowerBooks.BookIdsToNames[book.ItemId] };
+            var possibleNames = new[] { book.Name, PowerBooks.BookIdsToNames[book.ItemId], book.Name, ModBookIds.ModBookIdsToNames[book.ItemId] };
             var isThisBookRandomized = false;
             foreach (var possibleName in possibleNames)
             {

--- a/StardewArchipelago/Locations/CodeInjections/Vanilla/BookInjections.cs
+++ b/StardewArchipelago/Locations/CodeInjections/Vanilla/BookInjections.cs
@@ -161,7 +161,7 @@ namespace StardewArchipelago.Locations.CodeInjections.Vanilla
         {
             PlayReadBookAnimation(book, location);
 
-            var possibleNames = new[] { book.Name, PowerBooks.BookIdsToNames[book.ItemId], book.Name, ModBookIds.ModBookIdsToNames[book.ItemId] };
+            var possibleNames = new[] { book.Name, PowerBooks.BookIdsToNames[book.ItemId] };
             var isThisBookRandomized = false;
             foreach (var possibleName in possibleNames)
             {


### PR DESCRIPTION
Fixes the bug that would occur when using the book Digging Like Worms.  Also enables two checks, shipsanity and booksanity, presuming they're enabled in the yaml.