### PR TITLE
Build System and Documentation Improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -361,3 +361,6 @@ StardewArchipelago/.vscode/launch.json
 src/manifest.json
 StardewArchipelago/.vscode/tasks.json
 .vscode/launch.json
+
+# Custom
+/Directory.Build.props

--- a/.gitignore
+++ b/.gitignore
@@ -364,3 +364,4 @@ StardewArchipelago/.vscode/tasks.json
 
 # Custom
 /Directory.Build.props
+!.vscode/tasks.json

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,124 @@
+// Maintainance: Keep the "Choose build target" options and the "Build All" $targets list synchronized
+// with the targets defined in StardewArchipelago.sln
+{
+    // See https://go.microsoft.com/fwlink/?LinkId=733558
+    // for the documentation about the tasks.json format
+    "version": "2.0.0",
+    "inputs": [
+        {
+            "id": "conf",
+            "type": "pickString",
+            "description": "Choose build target",
+            "options": [
+                "Debug",
+                "Debug Tiles",
+                "Debug Tilesanity",
+                "Release",
+                "Release Tilesanity"
+            ],
+            "default": "Debug"
+        }
+    ],
+    "tasks": [
+        {
+            "label": "Build",
+            "type": "shell",
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            },
+            "command": "dotnet",
+            "args": [
+                "build",
+                "-c",
+                "${input:conf}",
+                "-p:EnableModDeploy=false",
+                "-p:EnableModZip=false"
+            ],
+            "options": {
+                "cwd": "${workspaceFolder}"
+            },
+            "problemMatcher": [
+                "$msCompile"
+            ]
+        },
+        {
+            "label": "Build All",
+            "type": "shell",
+            "group": "build",
+            "command": "powershell",
+            "args": [
+                "-NoProfile",
+                "-Command",
+                "$targets=@(\\\"Debug\\\",\\\"Debug Tiles\\\",\\\"Debug Tilesanity\\\",\\\"Release\\\",\\\"Release Tilesanity\\\"); foreach($t in $targets){ dotnet build -c $t -p:EnableModDeploy=false -p:EnableModZip=false; if($LASTEXITCODE -ne 0){ exit $LASTEXITCODE } }"
+            ],
+            "options": {
+                "cwd": "${workspaceFolder}"
+            },
+            "problemMatcher": [
+                "$msCompile"
+            ]
+        },
+        {
+            "label": "Deploy",
+            "type": "shell",
+            "hide": true,
+            "group": "build",
+            "command": "dotnet",
+            "args": [
+                "build",
+                "-c",
+                "${input:conf}"
+            ],
+            "options": {
+                "cwd": "${workspaceFolder}"
+            },
+            "problemMatcher": [
+                "$msCompile"
+            ]
+        },
+        {
+            "label": "Run",
+            "type": "shell",
+            "group": "build",
+            "dependsOn": "Deploy",
+            "command": "powershell",
+            "args": [
+                "-NoProfile",
+                "-Command",
+                "$game_path = Get-Content '${workspaceFolder}/StardewArchipelago/obj/game_path.txt'; & \"$game_path\\StardewModdingAPI.exe\""
+            ],
+            "options": {
+                "cwd": "${workspaceFolder}"
+            }
+        },
+        {
+            "label": "Test",
+            "type": "shell",
+            "group": "build",
+            "command": "dotnet",
+            "args": [
+                "test",
+                "-c",
+                "${input:conf}"
+            ],
+            "options": {
+                "cwd": "${workspaceFolder}"
+            },
+            "problemMatcher": [
+                "$msCompile"
+            ]
+        },
+        {
+            "label": "Clean",
+            "type": "shell",
+            "command": "dotnet clean",
+            "options": {
+                "cwd": "${workspaceFolder}"
+            },
+            "problemMatcher": [
+                "$msCompile"
+            ]
+        }
+    ]
+}

--- a/Documentation/Contributing/Contributing.md
+++ b/Documentation/Contributing/Contributing.md
@@ -2,11 +2,17 @@
 
 ## Introduction
 
-This mod is separated in two parts.
+This randomizer implementation maintained in two pieces:
 
-First, the actual mod, that players use in their Stardew Valley. This mod is coded in C#, and the standard Stardew Valley modding tutorials (like the ones on the wiki https://stardewvalleywiki.com/Modding:Modder_Guide/Get_Started) will be massively helpful to understand it.
+### StardewArchipelago
 
-Second, the backend, also called the `apworld`. This is in Python, and lives in the Archipelago Core repository, for the most part. This part handles the generator, the website, the hosting, etc. It can also be modified for purposes of compatibility with potential trackers. Other Stardew Valley mods have no such thing, so you'll find documentation and help on the [Archipelago Repository](https://github.com/ArchipelagoMW/Archipelago) and [Discord Server](https://discord.gg/8Z65BR2).
+*The repository you are current reading the documentation of.*
+
+This is the Stardew Valley mod that players use to connect to Archipelago to play randomized game instances. This mod is written in C# and the standard Stardew Valley modding tutorials (like the ones on the wiki https://stardewvalleywiki.com/Modding:Modder_Guide/Get_Started) will be massively helpful to understand how it works.
+
+### Archipelago World
+
+Also known as the the `apworld`. This is written in Python and is implemented as part of the [Main Archipelago Repository](https://github.com/ArchipelagoMW/Archipelago/tree/main/worlds/stardew_valley). This part handles the generator, the website, the hosting, etc. It can also be modified for purposes of compatibility with potential trackers. Other Stardew Valley mods have no such thing, so you'll find documentation and help on the [Archipelago Repository](https://github.com/ArchipelagoMW/Archipelago) and [Discord Server](https://discord.gg/8Z65BR2).
 
 ## Software
 
@@ -34,3 +40,15 @@ Everything on this list is available for free, for individuals.
   * [Archipelago Core](https://github.com/ArchipelagoMW/Archipelago), [my fork of it](https://github.com/agilbert1412/Archipelago), and your fork of it
   * [StardewArchipelago](https://github.com/agilbert1412/StardewArchipelago) and your fork of it
   * OPTIONAL - [ArchipelagoUtilities](https://github.com/agilbert1412/ArchipelagoUtilities) a set of utilities for my Archipelago mod, in case you need to modify something there (unlikely)
+
+## Game Path
+
+When building the application, MSBuild will attempt to automatically determine the location of your Stardew Valley installation. If for whatever reason this fails to identify to correct location, you can specify the path manually by adding a file called `Directory.Build.props` to the top level of this repository. Example contents:
+
+```xml
+<Project>
+  <PropertyGroup>
+    <GamePath>C:\Path\To\Stardew Valley</GamePath>
+  </PropertyGroup>
+</Project>
+```

--- a/README.md
+++ b/README.md
@@ -1,4 +1,15 @@
 # StardewArchipelago
-Archipelago Implementation for Stardew Valley
 
-Dedicated Discord Server: https://discord.gg/vgn7qCxRBW
+Archipelago implementation for Stardew Valley. Visit [archipelago.gg](https://archipelago.gg/) for additional information.
+
+## Links
+
+- [Stardew Valley Archipelago](https://archipelago.gg/games/Stardew%20Valley/info/en)
+
+- [Stardew Valley Archipelago Discord Server](https://discord.gg/vgn7qCxRBW)
+
+- [Archipelago Discord Server](https://discord.gg/8Z65BR2)
+
+## Contributing
+
+- [Contributing.md](./Documentation/Contributing/Contributing.md)

--- a/StardewArchipelago.sln
+++ b/StardewArchipelago.sln
@@ -26,7 +26,7 @@ Global
 		{95900FBD-BF44-485F-B89E-2BF0681F380A}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{95900FBD-BF44-485F-B89E-2BF0681F380A}.Release|Any CPU.Build.0 = Release|Any CPU
 		{95900FBD-BF44-485F-B89E-2BF0681F380A}.Debug Tiles|Any CPU.ActiveCfg = Debug Tiles|Any CPU
-        {95900FBD-BF44-485F-B89E-2BF0681F380A}.Debug Tiles|Any CPU.Build.0   = Debug Tiles|Any CPU
+		{95900FBD-BF44-485F-B89E-2BF0681F380A}.Debug Tiles|Any CPU.Build.0   = Debug Tiles|Any CPU
 		{95900FBD-BF44-485F-B89E-2BF0681F380A}.Debug Tilesanity|Any CPU.ActiveCfg = Debug Tilesanity|Any CPU
 		{95900FBD-BF44-485F-B89E-2BF0681F380A}.Debug Tilesanity|Any CPU.Build.0 = Debug Tilesanity|Any CPU
 		{95900FBD-BF44-485F-B89E-2BF0681F380A}.Release Tilesanity|Any CPU.ActiveCfg = Release Tilesanity|Any CPU

--- a/StardewArchipelago.sln
+++ b/StardewArchipelago.sln
@@ -26,6 +26,7 @@ Global
 		{95900FBD-BF44-485F-B89E-2BF0681F380A}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{95900FBD-BF44-485F-B89E-2BF0681F380A}.Release|Any CPU.Build.0 = Release|Any CPU
 		{95900FBD-BF44-485F-B89E-2BF0681F380A}.Debug Tiles|Any CPU.ActiveCfg = Debug Tiles|Any CPU
+        {95900FBD-BF44-485F-B89E-2BF0681F380A}.Debug Tiles|Any CPU.Build.0   = Debug Tiles|Any CPU
 		{95900FBD-BF44-485F-B89E-2BF0681F380A}.Debug Tilesanity|Any CPU.ActiveCfg = Debug Tilesanity|Any CPU
 		{95900FBD-BF44-485F-B89E-2BF0681F380A}.Debug Tilesanity|Any CPU.Build.0 = Debug Tilesanity|Any CPU
 		{95900FBD-BF44-485F-B89E-2BF0681F380A}.Release Tilesanity|Any CPU.ActiveCfg = Release Tilesanity|Any CPU

--- a/StardewArchipelago/Archipelago/ChatForwarder.cs
+++ b/StardewArchipelago/Archipelago/ChatForwarder.cs
@@ -17,6 +17,10 @@ using StardewValley;
 using StardewValley.Locations;
 using StardewValley.Menus;
 
+#if TILESANITY
+using StardewArchipelago.Archipelago.SlotData.SlotEnums;
+#endif
+
 namespace StardewArchipelago.Archipelago
 {
     public class ChatForwarder

--- a/StardewArchipelago/Items/ItemParser.cs
+++ b/StardewArchipelago/Items/ItemParser.cs
@@ -12,6 +12,10 @@ using StardewArchipelago.Stardew.NameMapping;
 using StardewModdingAPI;
 using StardewValley;
 
+#if TILESANITY
+using StardewArchipelago.GameModifications.CodeInjections.Tilesanity;
+#endif
+
 namespace StardewArchipelago.Items
 {
     public class ItemParser
@@ -45,7 +49,7 @@ namespace StardewArchipelago.Items
             if (TileUI.ProcessItem(receivedItem))
                 return true;
 #endif
-            
+
             if (_trapManager.IsTrap(receivedItem.ItemName))
             {
                 return _trapManager.TryExecuteTrapImmediately(receivedItem.ItemName);

--- a/StardewArchipelago/StardewArchipelago.csproj
+++ b/StardewArchipelago/StardewArchipelago.csproj
@@ -84,4 +84,10 @@
 			<CopyToOutputDirectory>Always</CopyToOutputDirectory>
 		</None>
 	</ItemGroup>
+	<Target Name="write_game_path" BeforeTargets="Build">
+		<WriteLinesToFile
+			File="$(BaseIntermediateOutputPath)game_path.txt"
+			Lines="$(GamePath)"
+			Overwrite="true" />
+	</Target>
 </Project>

--- a/StardewArchipelagoTests/StardewArchipelagoTests.csproj
+++ b/StardewArchipelagoTests/StardewArchipelagoTests.csproj
@@ -7,7 +7,7 @@
 
         <IsPackable>false</IsPackable>
 
-        <Configurations>Debug;Release;Debug tiles;Debug Tiles;Debug Tilesanity;Release Tilesanity</Configurations>
+        <Configurations>Debug;Release;Debug Tiles;Debug Tiles;Debug Tilesanity;Release Tilesanity</Configurations>
 
         <Platforms>AnyCPU</Platforms>
     </PropertyGroup>


### PR DESCRIPTION
# Changes

- Fix compilation issues for some solution configurations
- Add task definitions for Visual Studio Code
  - Emit the developer's Stardew Valley path as a build asset so the game can be launched directly from a VSCode task
- Update documentation

# How was this tested?

Validate the following on .NET v8.0.412:
- All 5 project configurations (`Debug`, `Debug Tiles`, `Debug Tilesanity`, `Release` and `Release Tilesanity`) build with 0 errors
- All 5 project configurations pass unit tests (`dotnet test`)

# Follow-Up Concerns

Food for thought. These don't all need immediate answers.

- Do we need to continue maintaining all 5 build configurations?
  - Why were some broken to begin with?
  - At what point does an experimental feature just get folded into `Debug`/`Release`?
- How important is `GatchaRollerTests`? It takes 600x more time to run that one test than all others combined on my machine.