### PR TITLE
Add git pre-commit to ensure packages.lock.json is kept up-to-date

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,2 @@
+#!/usr/bin/env sh
+git add **/packages.lock.json

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,2 +1,4 @@
 #!/usr/bin/env sh
+cd "$(dirname "${BASH_SOURCE[0]}/..")"
+dotnet restore
 git add **/packages.lock.json

--- a/.githooks/pre-commit.bat
+++ b/.githooks/pre-commit.bat
@@ -1,0 +1,3 @@
+@echo off
+git add **/packages.lock.json
+exit /b %ERRORLEVEL%

--- a/.githooks/pre-commit.bat
+++ b/.githooks/pre-commit.bat
@@ -1,3 +1,5 @@
 @echo off
+cd /d "%~dp0"
+dotnet restore
 git add **/packages.lock.json
 exit /b %ERRORLEVEL%

--- a/StardewArchipelago/packages.lock.json
+++ b/StardewArchipelago/packages.lock.json
@@ -25,9 +25,9 @@
       },
       "KaitoKid.ArchipelagoUtilities.Net": {
         "type": "Direct",
-        "requested": "[2.0.3, )",
-        "resolved": "2.0.3",
-        "contentHash": "nBBsIoXcpX3eIqjTirONLsolG4kn76BRXXFAVRydDi6V1W3yTt5AJy+qEYP229Kz1m97/EbAjHKR/+tSxrtR4g==",
+        "requested": "[2.0.4, )",
+        "resolved": "2.0.4",
+        "contentHash": "222dDKmtyoy4iTQbNX3pVX9m/AAS5UJOk/ymwXSQu625m2EN9X/H/RA3XWwUUvhPaMEO4rLsGTML2U/gwNA6lA==",
         "dependencies": {
           "Archipelago.MultiClient.Net": "6.6.0"
         }

--- a/StardewArchipelagoTests/packages.lock.json
+++ b/StardewArchipelagoTests/packages.lock.json
@@ -63,8 +63,8 @@
       },
       "KaitoKid.ArchipelagoUtilities.Net": {
         "type": "Transitive",
-        "resolved": "2.0.3",
-        "contentHash": "nBBsIoXcpX3eIqjTirONLsolG4kn76BRXXFAVRydDi6V1W3yTt5AJy+qEYP229Kz1m97/EbAjHKR/+tSxrtR4g==",
+        "resolved": "2.0.4",
+        "contentHash": "222dDKmtyoy4iTQbNX3pVX9m/AAS5UJOk/ymwXSQu625m2EN9X/H/RA3XWwUUvhPaMEO4rLsGTML2U/gwNA6lA==",
         "dependencies": {
           "Archipelago.MultiClient.Net": "6.6.0"
         }
@@ -582,7 +582,7 @@
         "dependencies": {
           "Archipelago.Gifting.Net": "[0.4.3, )",
           "Archipelago.MultiClient.Net": "[6.6.1, )",
-          "KaitoKid.ArchipelagoUtilities.Net": "[2.0.3, )",
+          "KaitoKid.ArchipelagoUtilities.Net": "[2.0.4, )",
           "Pathoschild.Stardew.ModBuildConfig": "[4.4.0, )"
         }
       }


### PR DESCRIPTION
# Changes

- Update the package lockfiles to match the current project state
- Add pre-commit hooks for linux/windows to regenerate and automatically stage both `packages.lock.json` files just before committing

# How was this tested

- I did not manually stage the lockfiles, yet they were committed regardless