### PR TITLE
Adds a setting to skip all received npc friendship gifts

### DIFF
--- a/StardewArchipelago/Integrations/GenericModConfigMenu/ConfigMenu.cs
+++ b/StardewArchipelago/Integrations/GenericModConfigMenu/ConfigMenu.cs
@@ -134,6 +134,14 @@ namespace StardewArchipelago.Integrations.GenericModConfigMenu
 
             configMenu.AddBoolOption(
                 mod: ModManifest,
+                name: () => "Hide NPC Gift Mail",
+                tooltip: () => "All received NPC gifts will be skipped and trashed, reducing clutter when multisleeping",
+                getValue: () => Config.HideNpcGiftMail,
+                setValue: (value) => Config.HideNpcGiftMail = value
+            );
+
+            configMenu.AddBoolOption(
+                mod: ModManifest,
                 name: () => "Disable Letter Templates",
                 tooltip: () => "All Archipelago letters will now use a very short and concise format instead of the funny ones full of fluff",
                 getValue: () => Config.DisableLetterTemplates,

--- a/StardewArchipelago/Integrations/GenericModConfigMenu/ConfigMenu.cs
+++ b/StardewArchipelago/Integrations/GenericModConfigMenu/ConfigMenu.cs
@@ -135,7 +135,7 @@ namespace StardewArchipelago.Integrations.GenericModConfigMenu
             configMenu.AddBoolOption(
                 mod: ModManifest,
                 name: () => "Hide NPC Gift Mail",
-                tooltip: () => "All received NPC gifts will be skipped and trashed, reducing clutter when multisleeping",
+                tooltip: () => "All received NPC gifts will be skipped, reducing clutter",
                 getValue: () => Config.HideNpcGiftMail,
                 setValue: (value) => Config.HideNpcGiftMail = value
             );

--- a/StardewArchipelago/Items/Mail/MailPatcher.cs
+++ b/StardewArchipelago/Items/Mail/MailPatcher.cs
@@ -48,7 +48,6 @@ namespace StardewArchipelago.Items.Mail
                 prefix: new HarmonyMethod(typeof(MailPatcher), nameof(Mailbox_HideEmptyApLetters_Prefix))
                 );
             }
-
             
             if (ModEntry.Instance.Config.HideNpcGiftMail)
             {

--- a/StardewArchipelago/ModConfig.cs
+++ b/StardewArchipelago/ModConfig.cs
@@ -16,6 +16,12 @@ namespace StardewArchipelago
         /// Examples include NPC Hearts, Seasons, Carpenter building unlocks, etc
         /// </summary>
         public bool HideEmptyArchipelagoLetters { get; set; } = false;
+        
+        /// <summary>
+        /// Automatically removes random gifts received in mail from NPCs
+        /// Finds which letters are random gifts by checking the letter names for the specific keys
+        /// </summary>
+        public bool HideNpcGiftMail { get; set; } = false;
 
         /// <summary>
         /// All Archipelago letters will now use a very short and concise format

--- a/StardewArchipelago/ModConfig.cs
+++ b/StardewArchipelago/ModConfig.cs
@@ -19,7 +19,6 @@ namespace StardewArchipelago
         
         /// <summary>
         /// Automatically removes random gifts received in mail from NPCs
-        /// Finds which letters are random gifts by checking the letter names for the specific keys
         /// </summary>
         public bool HideNpcGiftMail { get; set; } = false;
 


### PR DESCRIPTION
Add's a config setting to skip gifts randomly received from NPC friends, as they could build up to hundreds after multisleeping too long if you have many friends.
Code used was heavily based off code for skipping empty letters.

Tested locally with setting both on and off. Noticed an issue where if the first message is a gift, it doesn't get skipped, but that is the same behavior as what skipping empty letters does.