### PR TITLE
Add backpack_size.md to Yaml Settings documentation

### DIFF
--- a/Documentation/Yaml Settings/backpack_progression.md
+++ b/Documentation/Yaml Settings/backpack_progression.md
@@ -34,7 +34,7 @@ The definition of "Early" is handled by Archipelago core, and out of our hands.
 
 ### Backpack Size
 
-Through the setting ~~[Backpack Size](./backpack_size.md)~~, the player can customize the size of each backpack upgrade. The default value is 12, like in vanilla.
+Through the setting [Backpack Size](./backpack_size.md), the player can customize the size of each backpack upgrade. The default value is 12, like in vanilla.
 
 This means that, instead of having 2 backpack upgrades of 12 slots each, you can have 6 upgrades of 4 slots each, or at the most, 24 upgrades of 1 slot each.
 

--- a/Documentation/Yaml Settings/backpack_size.md
+++ b/Documentation/Yaml Settings/backpack_size.md
@@ -1,0 +1,47 @@
+# Stardew Valley Archipelago - Backpack Size
+
+## Backpack Size
+
+This setting allows you to choose how many inventory slots each `Progressive Backpack` items gives you.
+
+### Option Values
+
+You can choose from a backpack size of 1, 2, 3, 4, 6, or 12 (default value; corresponds with vanilla backpack size). These values were chosen because they can cleanly multiply into 36 while still allowing for the vanilla starting amount of 12 to be possible.
+
+### Items
+
+Depending on the size you choose, as well as whether you start without a [backpack](./start_without.md#backpack) or [tools](./start_without.md#tools), a certain number of `Progressive Backpack` items will be in the pool, such that you end up with 36 inventory slots after they all have been obtained. Here is a summary:
+
+| Backpack Size | Backpacks in Pool (With Starting Backpack) | Backpacks in Pool (Without Starting Backpack) | Backpacks in Pool (Without Starting Backpack or Tools) |
+|---------------|--------------------------------------------|-----------------------------------------------|--------------------------------------------------------|
+| 1             | 24                                         | 30                                            | 32                                                     |
+| 2             | 12                                         | 15                                            | 16                                                     |
+| 3             | 8                                          | 10                                            | 10                                                     |
+| 4             | 6                                          | 7                                             | 8                                                      |
+| 6             | 4                                          | 5                                             | 5                                                      |
+| 12            | 2                                          | 2                                             | 2                                                      |
+
+Note that starting without tools but with the backpack will not affect the number of `Progressive Backpack` items in the pool.
+
+### Locations
+
+Additional backpacks will be added to Pierre's General Store if you use a backpack size less than 12. The price for each backpack will total to the amount the original backpack would be worth. For example, the total price of every `Large Pack` upgrade will total 2000g, but split between multiple upgrades, with a growth curve so that every upgrade costs more than the previous one. (Do you think something more should be added to this? Like, maybe another table or something?)
+You can still only purchase upgrade `N`, after receiving backpack `N-1`
+
+### Disclaimer
+
+In the game, there is a keybind to swap your hotbar with the next row of inventory.
+This feature is extremely wonky when used with backpacks of a size that is not a multiple of 12 because it offsets your inventory by 12 slots (1 row), and it will therefore lead to items suddenly switching columns from one cycle to the next.
+This is generally considered undesirable, so if you rely on this keybind a lot, smaller backpack sizes might be annoying for you.
+
+## Interaction With Other Settings
+
+### Backpack Progression
+
+When [Backpack Progression](./backpack_progression.md) is set to `Early Progressive`, only one `Progressive Backpack` will be attempted to be placed early. This means that, with a small backpack size, you might not get as much out of this setting as you would otherwise. (Is this phrasing good?)
+
+### Start Without Backpack
+
+Within the setting [Start Without](./start_without.md), is a setting to "Start Without: Backpack". When this is enabled and the backpack size is set to anything other than 12, some `Small Pack` locations will be added to Pierre's General Store to purchase at the start, whose prices will add up to 500g.
+
+## [Return to Index](./index.md)

--- a/Documentation/Yaml Settings/backpack_size.md
+++ b/Documentation/Yaml Settings/backpack_size.md
@@ -40,18 +40,18 @@ When [Backpack Progression](./backpack_progression.md) is set to `Early Progress
 
 ### Start Without
 
-Within the setting [Start Without](./start_without.md), is a setting to "Start Without: Backpack". When this is enabled and the backpack size is set to anything other than 12, some `Small Pack` locations will be added to Pierre's General Store to purchase at the start, whose prices will add up to 500g. Additionally, the number of `Progressive Backpack` items in the pool will be adjusted so that you will still end up with 36 inventory slots after receiving all of them. Starting without tools also affects how many inventory slots you start with, thus further adjusting the amount of backpacks in the pool.
+Within the setting [Start Without](./start_without.md), is a setting to "Start Without: Backpack". When this is enabled and the backpack size is set to anything other than 12, some `Small Pack` locations will be added to Pierre's General Store to purchase at the start, whose prices will add up to 500g. Additionally, the number of `Progressive Backpack` items in the pool will be adjusted so that you will still end up with 36 inventory slots after receiving all of them. Starting without tools also affects how many inventory slots you start with, thus further adjusting the amount of backpacks in the item pool.
 
-Here is a summary of how `Start Without` interacts with each backpack size:
+Here is a summary of how many `Progressive Backpack ` items you start with and are in the pool for each combination of `Start Without` and backpack size:
 
-| Backpack Size | Backpacks in Pool (Without Starting Backpack) | Backpacks in Pool (Without Starting Backpack or Tools) |
-|---------------|-----------------------------------------------|--------------------------------------------------------|
-| 1             | 30                                            | 32                                                     |
-| 2             | 15                                            | 16                                                     |
-| 3             | 10                                            | 10                                                     |
-| 4             | 7                                             | 8                                                      |
-| 6             | 5                                             | 5                                                      |
-| 12            | 2                                             | 2                                                      |
+| Backpack Size | Without Starting Backpack | Without Starting Backpack or Tools |
+|---------------|---------------------------|------------------------------------|
+| 1             | 6 starting, 30 in pool    | 4 starting, 32 in pool             |
+| 2             | 3 starting, 15 in pool    | 2 starting, 16 in pool             |
+| 3             | 2 starting, 10 in pool    | 2 starting, 10 in pool             |
+| 4             | 2 starting, 7 in pool     | 1 starting, 8 in pool              |
+| 6             | 1 starting, 5 in pool     | 1 starting, 5 in pool              |
+| 12            | 1 starting, 2 in pool     | 1 starting, 2 in pool              |
 
 Note that starting without tools but with the backpack will not affect the number of `Progressive Backpack` items in the pool.
 

--- a/Documentation/Yaml Settings/backpack_size.md
+++ b/Documentation/Yaml Settings/backpack_size.md
@@ -6,26 +6,24 @@ This setting allows you to choose how many inventory slots each `Progressive Bac
 
 ### Option Values
 
-You can choose from a backpack size of 1, 2, 3, 4, 6, or 12 (default value; corresponds with vanilla backpack size). These values were chosen because they can cleanly multiply into 36 while still allowing for the vanilla starting amount of 12 to be possible.
+You can choose from a backpack size of 1, 2, 3, 4, 6, or 12, with 12 being the default value because it corresponds with the vanilla backpack size. These values were chosen because they can cleanly multiply into 36 while still allowing for the vanilla starting amount of 12 to be possible.
 
 ### Items
 
-Depending on the size you choose, as well as whether you start without a [backpack](./start_without.md#backpack) or [tools](./start_without.md#tools), a certain number of `Progressive Backpack` items will be in the pool, such that you end up with 36 inventory slots after they all have been obtained. Here is a summary:
+Depending on the backpack size you choose, additional `Progressive Backpack` items will be added to the pool, such that you end up with 36 inventory slots after they all have been obtained. Here is a summary of how many backpacks you can expect to find with each backpack size value:
 
-| Backpack Size | Backpacks in Pool (With Starting Backpack) | Backpacks in Pool (Without Starting Backpack) | Backpacks in Pool (Without Starting Backpack or Tools) |
-|---------------|--------------------------------------------|-----------------------------------------------|--------------------------------------------------------|
-| 1             | 24                                         | 30                                            | 32                                                     |
-| 2             | 12                                         | 15                                            | 16                                                     |
-| 3             | 8                                          | 10                                            | 10                                                     |
-| 4             | 6                                          | 7                                             | 8                                                      |
-| 6             | 4                                          | 5                                             | 5                                                      |
-| 12            | 2                                          | 2                                             | 2                                                      |
-
-Note that starting without tools but with the backpack will not affect the number of `Progressive Backpack` items in the pool.
+| Backpack Size | Backpacks in Pool |
+|---------------|-------------------|
+| 1             | 24                |
+| 2             | 12                |
+| 3             | 8                 |
+| 4             | 6                 |
+| 6             | 4                 |
+| 12            | 2                 |
 
 ### Locations
 
-Additional backpacks will be added to Pierre's General Store if you use a backpack size less than 12. The price for each backpack will total to the amount the original backpack would be worth. For example, the total price of every `Large Pack` upgrade will total 2000g, but split between multiple upgrades, with a growth curve so that every upgrade costs more than the previous one. (Do you think something more should be added to this? Like, maybe another table or something?)
+Additional backpacks will be added to Pierre's General Store if you use a backpack size less than 12. The price for each backpack will total to the amount the original backpack would be worth. For example, the total price of every `Large Pack` upgrade will total 2000g, but split between multiple upgrades, with a growth curve so that every upgrade costs more than the previous one.
 You can still only purchase upgrade `N`, after receiving backpack `N-1`
 
 ### Disclaimer
@@ -38,10 +36,23 @@ This is generally considered undesirable, so if you rely on this keybind a lot, 
 
 ### Backpack Progression
 
-When [Backpack Progression](./backpack_progression.md) is set to `Early Progressive`, only one `Progressive Backpack` will be attempted to be placed early. This means that, with a small backpack size, you might not get as much out of this setting as you would otherwise. (Is this phrasing good?)
+When [Backpack Progression](./backpack_progression.md) is set to `Early Progressive`, only one `Progressive Backpack` will be attempted to be placed early. This means that, with a small backpack size, you might not get as much out of this setting as you would with a larger backpack size.
 
-### Start Without Backpack
+### Start Without
 
-Within the setting [Start Without](./start_without.md), is a setting to "Start Without: Backpack". When this is enabled and the backpack size is set to anything other than 12, some `Small Pack` locations will be added to Pierre's General Store to purchase at the start, whose prices will add up to 500g.
+Within the setting [Start Without](./start_without.md), is a setting to "Start Without: Backpack". When this is enabled and the backpack size is set to anything other than 12, some `Small Pack` locations will be added to Pierre's General Store to purchase at the start, whose prices will add up to 500g. Additionally, the number of `Progressive Backpack` items in the pool will be adjusted so that you will still end up with 36 inventory slots after receiving all of them. Starting without tools also affects how many inventory slots you start with, thus further adjusting the amount of backpacks in the pool.
+
+Here is a summary of how `Start Without` interacts with each backpack size:
+
+| Backpack Size | Backpacks in Pool (Without Starting Backpack) | Backpacks in Pool (Without Starting Backpack or Tools) |
+|---------------|-----------------------------------------------|--------------------------------------------------------|
+| 1             | 30                                            | 32                                                     |
+| 2             | 15                                            | 16                                                     |
+| 3             | 10                                            | 10                                                     |
+| 4             | 7                                             | 8                                                      |
+| 6             | 5                                             | 5                                                      |
+| 12            | 2                                             | 2                                                      |
+
+Note that starting without tools but with the backpack will not affect the number of `Progressive Backpack` items in the pool.
 
 ## [Return to Index](./index.md)

--- a/Documentation/Yaml Settings/index.md
+++ b/Documentation/Yaml Settings/index.md
@@ -89,7 +89,7 @@ These settings cannot be picked from the website, and require filling out your y
 These settings are only available in the 7.x.x Pre-release version of the mod
 
 - ~~[Bundles Per Room](./bundle_per_room.md)~~
-- ~~[Backpack Size](./backpack_size.md)~~
+- [Backpack Size](./backpack_size.md)
 - [Start Without](./start_without.md)
 - ~~[Eatsanity](./eatsanity.md)~~
 - ~~[Moviesanity](./moviesanity.md)~~

--- a/Documentation/Yaml Settings/start_without.md
+++ b/Documentation/Yaml Settings/start_without.md
@@ -17,7 +17,7 @@ Enabling any of these will mean you will start without them when you generate a 
 
 When this is enabled, you will start without any inventory slots. You will need to check the mailbox in order to gain access to some inventory slots; the backpacks will always be in the first couple of messages. 
 
-The number of inventory slots you receive will depend on your ~~[Backpack Size](./backpack_size.md)~~ setting - generally, though, you will be given enough backpacks to have at least 6 inventory slots (4 if you start without tools). These amounts have been deemed to be the bare minimum to be able to complete every location check in the game without having to write convoluted inventory logic.
+The number of inventory slots you receive will depend on your [Backpack Size](./backpack_size.md) setting - generally, though, you will be given enough backpacks to have at least 6 inventory slots (4 if you start without tools). These amounts have been deemed to be the bare minimum to be able to complete every location check in the game without having to write convoluted inventory logic.
 It is possible that, in the future, we eventually write the convoluted inventory logic, and allow the player to start with a true zero-slot backpack.
 
 Here is what you will start with given a specific backpack size:


### PR DESCRIPTION
This adds the backpack_size.md file to the Yaml Settings documentation, as well as fixing some links in other files to link to backpack_size.md. As always, I acknowledge that this is just a first draft, and changes will likely need to be made.